### PR TITLE
sendBySmsメソッドの不要な引数を削除

### DIFF
--- a/Service/CustomerTwoFactorAuthService.php
+++ b/Service/CustomerTwoFactorAuthService.php
@@ -345,9 +345,13 @@ class CustomerTwoFactorAuthService
     /**
      * SMSで顧客電話番号へメッセージを送信.
      *
-     * @param \Eccube\Entity\Customer $Customer
+     * @param $phoneNumber
+     * @param $body
+     * @return \Twilio\Rest\Api\V2010\Account\MessageInstance
+     * @throws \Twilio\Exceptions\ConfigurationException
+     * @throws \Twilio\Exceptions\TwilioException
      */
-    public function sendBySms($Customer, $phoneNumber, $body)
+    public function sendBySms($phoneNumber, $body)
     {
         // Twilio
         $twilio = new \Twilio\Rest\Client(


### PR DESCRIPTION
TwoFactorAuthCustomerSms42では$Customerは引数に指定されていませんし、 メソッド内で$Customerは使用されてないのでsendBySmsメソッドの引数から削除しました。

あとsendBySmsメソッドは汎用性がなさそうなのでTwoFactorAuthCustomerSms42に組み込んだほうが良いんじゃないかと思いました。