### PR TITLE
２段階認証項目表示の変更

### DIFF
--- a/Event.php
+++ b/Event.php
@@ -13,7 +13,10 @@
 
 namespace Plugin\TwoFactorAuthCustomer42;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Eccube\Event\TemplateEvent;
+use Eccube\Repository\BaseInfoRepository;
+use Plugin\TwoFactorAuthCustomer42\Repository\TwoFactorAuthTypeRepository;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -22,12 +25,33 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 class Event implements EventSubscriberInterface
 {
     /**
+     * @var \Eccube\Entity\BaseInfo
+     */
+    private \Eccube\Entity\BaseInfo $BaseInfo;
+
+    /**
+     * @var EntityManagerInterface
+     */
+    private EntityManagerInterface $entityManager;
+
+    /**
+     * @var bool
+     */
+    private bool $hasActiveAuthType;
+
+    /**
      * Event constructor.
      *
      * @throws \Exception
      */
-    public function __construct()
-    {
+    public function __construct(
+        BaseInfoRepository $baseInfoRepository,
+        TwoFactorAuthTypeRepository $twoFactorAuthTypeRepository,
+        EntityManagerInterface $entityManager
+    ) {
+        $this->BaseInfo = $baseInfoRepository->get();
+        $this->hasActiveAuthType = $twoFactorAuthTypeRepository->findOneBy(['isDisabled' => false]) !== null;
+        $this->entityManager = $entityManager;
     }
 
     public static function getSubscribedEvents(): array
@@ -46,13 +70,15 @@ class Event implements EventSubscriberInterface
      */
     public function onRenderAdminShopSettingEdit(TemplateEvent $event)
     {
-        // add twig
+        // add 本人確認認証 twig
         $twig = 'TwoFactorAuthCustomer42/Resource/template/admin/shop_edit_sms.twig';
         $event->addSnippet($twig);
 
-        // add twig
-        $twig = 'TwoFactorAuthCustomer42/Resource/template/admin/shop_edit_tfa.twig';
-        $event->addSnippet($twig);
+        if ($this->hasActiveAuthType) {
+            // add ２段階認証設定 twig
+            $twig = 'TwoFactorAuthCustomer42/Resource/template/admin/shop_edit_tfa.twig';
+            $event->addSnippet($twig);
+        }
     }
 
     /**

--- a/Event.php
+++ b/Event.php
@@ -13,9 +13,7 @@
 
 namespace Plugin\TwoFactorAuthCustomer42;
 
-use Doctrine\ORM\EntityManagerInterface;
 use Eccube\Event\TemplateEvent;
-use Eccube\Repository\BaseInfoRepository;
 use Plugin\TwoFactorAuthCustomer42\Repository\TwoFactorAuthTypeRepository;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -24,16 +22,6 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class Event implements EventSubscriberInterface
 {
-    /**
-     * @var \Eccube\Entity\BaseInfo
-     */
-    private \Eccube\Entity\BaseInfo $BaseInfo;
-
-    /**
-     * @var EntityManagerInterface
-     */
-    private EntityManagerInterface $entityManager;
-
     /**
      * @var bool
      */
@@ -44,14 +32,9 @@ class Event implements EventSubscriberInterface
      *
      * @throws \Exception
      */
-    public function __construct(
-        BaseInfoRepository $baseInfoRepository,
-        TwoFactorAuthTypeRepository $twoFactorAuthTypeRepository,
-        EntityManagerInterface $entityManager
-    ) {
-        $this->BaseInfo = $baseInfoRepository->get();
+    public function __construct(TwoFactorAuthTypeRepository $twoFactorAuthTypeRepository)
+    {
         $this->hasActiveAuthType = $twoFactorAuthTypeRepository->findOneBy(['isDisabled' => false]) !== null;
-        $this->entityManager = $entityManager;
     }
 
     public static function getSubscribedEvents(): array

--- a/Form/Type/Extension/Admin/TwoFactorAuthBaseSettingTypeExtension.php
+++ b/Form/Type/Extension/Admin/TwoFactorAuthBaseSettingTypeExtension.php
@@ -16,6 +16,7 @@ namespace Plugin\TwoFactorAuthCustomer42\Form\Type\Extension\Admin;
 use Doctrine\ORM\EntityManagerInterface;
 use Eccube\Form\Type\Admin\ShopMasterType;
 use Eccube\Form\Type\ToggleSwitchType;
+use Plugin\TwoFactorAuthCustomer42\Entity\TwoFactorAuthType;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
@@ -61,11 +62,16 @@ class TwoFactorAuthBaseSettingTypeExtension extends AbstractTypeExtension
 
         $builder->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event) {
             $form = $event->getForm();
-            $form->add('two_factor_auth_use', ToggleSwitchType::class, [
-                'required' => false,
-                'mapped' => true,
-            ])
-                ->add('option_activate_device', ToggleSwitchType::class, [
+
+            if ($this->entityManager->getRepository(TwoFactorAuthType::class)->findOneBy(['isDisabled' => false]) !== null) {
+                $form->add('two_factor_auth_use', ToggleSwitchType::class, [
+                    'required' => false,
+                    'mapped' => true,
+                    'disabled' => true,
+                ]);
+            }
+
+            $form->add('option_activate_device', ToggleSwitchType::class, [
                     'required' => false,
                     'mapped' => true,
                 ]);

--- a/Form/Type/Extension/Admin/TwoFactorAuthBaseSettingTypeExtension.php
+++ b/Form/Type/Extension/Admin/TwoFactorAuthBaseSettingTypeExtension.php
@@ -67,7 +67,6 @@ class TwoFactorAuthBaseSettingTypeExtension extends AbstractTypeExtension
                 $form->add('two_factor_auth_use', ToggleSwitchType::class, [
                     'required' => false,
                     'mapped' => true,
-                    'disabled' => true,
                 ]);
             }
 


### PR DESCRIPTION
下記のIssueについて、
https://github.com/EC-CUBE/TwoFactorAuthCustomer42/issues/33

二段階認証のプラグイン（APPorSMS）がない状態であれば、二段階認証項目の非表示状態になるように修正しました。
