### PR TITLE
APIトークン項目マスキングの実施

### DIFF
--- a/Resource/template/admin/config.twig
+++ b/Resource/template/admin/config.twig
@@ -41,7 +41,7 @@
                                         <span
                                             class="badge bg-primary ms-1">{{ 'admin.common.required'|trans }}</span></label>
                                     <div class="col mb-2">
-                                        {{ form_widget(form.api_secret) }}
+                                        {{ form_widget(form.api_secret, { type : 'password'}) }}
                                         {{ form_errors(form.api_secret) }}
                                     </div>
                                 </div>


### PR DESCRIPTION
APIトークン項目のパスワード欄のような表示になるように更新しました。

https://github.com/EC-CUBE/TwoFactorAuthCustomer42/issues/19
