### PR TITLE
ワンタイムパスワード・マジックナンバーの生成処理のコード整理

### DIFF
--- a/Entity/CustomerTrait.php
+++ b/Entity/CustomerTrait.php
@@ -77,19 +77,6 @@ trait CustomerTrait
     private $TwoFactorAuthCustomerCookies;
 
     /**
-     * @param string $hashedOneTimePassword
-     *
-     * @return void
-     */
-    public function createDeviceAuthOneTimeToken(string $hashedOneTimePassword): void
-    {
-        $now = new \DateTime();
-
-        $this->setDeviceAuthOneTimeToken($hashedOneTimePassword);
-        $this->setDeviceAuthOneTimeTokenExpire($now->modify('+5 mins'));
-    }
-
-    /**
      * @return string
      */
     public function getDeviceAuthOneTimeToken(): ?string

--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -20,7 +20,6 @@ parameters:
   env(PLUGIN_ECCUBE_2FA_ROUTE_CUSTOMER_COOKIE_NAME): 'plugin_eccube_route_customer_2fa'
   env(PLUGIN_ECCUBE_2FA_ROUTE_CUSTOMER_EXPIRE): '3600'
   env(PLUGIN_ECCUBE_2FA_ROUTE_COOKIE_VALUE_CHARACTER_LENGTH): '64'
-  env(PLUGIN_ECCUBE_2FA_ONE_TIME_TOKEN_LENGTH): '6'
   env(PLUGIN_ECCUBE_2FA_ONE_TIME_TOKEN_EXPIRE_AFTER_SECONDS): '300'
 
   plugin_eccube_2fa_customer_cookie_name: '%env(PLUGIN_ECCUBE_2FA_CUSTOMER_COOKIE_NAME)%'
@@ -28,5 +27,4 @@ parameters:
   plugin_eccube_2fa_customer_expire: '%env(PLUGIN_ECCUBE_2FA_CUSTOMER_EXPIRE)%'
   plugin_eccube_2fa_route_customer_expire: '%env(PLUGIN_ECCUBE_2FA_ROUTE_CUSTOMER_EXPIRE)%'
   plugin_eccube_2fa_route_cookie_value_character_length: '%env(PLUGIN_ECCUBE_2FA_ROUTE_COOKIE_VALUE_CHARACTER_LENGTH)%'
-  plugin_eccube_2fa_one_time_token_length: '%env(PLUGIN_ECCUBE_2FA_ONE_TIME_TOKEN_LENGTH)%'
   plugin_eccube_2fa_one_time_token_expire_after_seconds: '%env(PLUGIN_ECCUBE_2FA_ONE_TIME_TOKEN_EXPIRE_AFTER_SECONDS)%'

--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -20,9 +20,13 @@ parameters:
   env(PLUGIN_ECCUBE_2FA_ROUTE_CUSTOMER_COOKIE_NAME): 'plugin_eccube_route_customer_2fa'
   env(PLUGIN_ECCUBE_2FA_ROUTE_CUSTOMER_EXPIRE): '3600'
   env(PLUGIN_ECCUBE_2FA_ROUTE_COOKIE_VALUE_CHARACTER_LENGTH): '64'
+  env(PLUGIN_ECCUBE_2FA_ONE_TIME_TOKEN_LENGTH): '6'
+  env(PLUGIN_ECCUBE_2FA_ONE_TIME_TOKEN_EXPIRE_AFTER_SECONDS): '300'
 
   plugin_eccube_2fa_customer_cookie_name: '%env(PLUGIN_ECCUBE_2FA_CUSTOMER_COOKIE_NAME)%'
   plugin_eccube_2fa_route_customer_cookie_name: '%env(PLUGIN_ECCUBE_2FA_ROUTE_CUSTOMER_COOKIE_NAME)%'
   plugin_eccube_2fa_customer_expire: '%env(PLUGIN_ECCUBE_2FA_CUSTOMER_EXPIRE)%'
   plugin_eccube_2fa_route_customer_expire: '%env(PLUGIN_ECCUBE_2FA_ROUTE_CUSTOMER_EXPIRE)%'
   plugin_eccube_2fa_route_cookie_value_character_length: '%env(PLUGIN_ECCUBE_2FA_ROUTE_COOKIE_VALUE_CHARACTER_LENGTH)%'
+  plugin_eccube_2fa_one_time_token_length: '%env(PLUGIN_ECCUBE_2FA_ONE_TIME_TOKEN_LENGTH)%'
+  plugin_eccube_2fa_one_time_token_expire_after_seconds: '%env(PLUGIN_ECCUBE_2FA_ONE_TIME_TOKEN_EXPIRE_AFTER_SECONDS)%'

--- a/Service/CustomerTwoFactorAuthService.php
+++ b/Service/CustomerTwoFactorAuthService.php
@@ -43,6 +43,12 @@ class CustomerTwoFactorAuthService
      * @var string コールバックURL
      */
     public const SESSION_CALL_BACK_URL = 'plugin_eccube_customer_2fa_call_back_url';
+
+    /**
+     * ワンタイムトークンの桁数
+     */
+    public const TOKEN_LENGTH = 6;
+
     /**
      * @var ContainerInterface
      */
@@ -115,11 +121,6 @@ class CustomerTwoFactorAuthService
     private TwoFactorAuthCustomerCookieRepository $twoFactorCustomerCookieRepository;
 
     /**
-     * @var int
-     */
-    private int $tokenLength;
-
-    /**
      * @var PasswordHasherFactoryInterface
      */
     private PasswordHasherFactoryInterface $hashFactory;
@@ -155,7 +156,6 @@ class CustomerTwoFactorAuthService
 
         $this->expire = (int) $this->eccubeConfig->get('plugin_eccube_2fa_customer_expire');
         $this->route_expire = (int) $this->eccubeConfig->get('plugin_eccube_2fa_route_customer_expire');
-        $this->tokenLength = (int) $this->eccubeConfig->get('plugin_eccube_2fa_one_time_token_length');
         $this->tokenActiveDurationSeconds = (int) $this->eccubeConfig->get('plugin_eccube_2fa_one_time_token_expire_after_seconds');
 
         $this->twoFactorAuthConfig = $twoFactorAuthConfigRepository->findOne();
@@ -402,7 +402,7 @@ class CustomerTwoFactorAuthService
     public function generateOneTimeTokenValue(?int $tokenLengthOverride = null): string
     {
         $token = '';
-        for ($i = 0; $i < ($tokenLengthOverride ?? $this->tokenLength); $i++) {
+        for ($i = 0; $i < ($tokenLengthOverride ?? self::TOKEN_LENGTH); $i++) {
             $token .= random_int(0, 9);
         }
 

--- a/Service/CustomerTwoFactorAuthService.php
+++ b/Service/CustomerTwoFactorAuthService.php
@@ -108,12 +108,23 @@ class CustomerTwoFactorAuthService
         'shopping',
         'shopping_login',
     ];
+
+    /**
+     * @var TwoFactorAuthCustomerCookieRepository
+     */
     private TwoFactorAuthCustomerCookieRepository $twoFactorCustomerCookieRepository;
+
+    /**
+     * @var int
+     */
+    private int $tokenLength;
 
     /**
      * @var PasswordHasherFactoryInterface
      */
     private PasswordHasherFactoryInterface $hashFactory;
+
+    private int $tokenActiveDurationSeconds;
 
     /**
      * constructor.
@@ -144,6 +155,8 @@ class CustomerTwoFactorAuthService
 
         $this->expire = (int) $this->eccubeConfig->get('plugin_eccube_2fa_customer_expire');
         $this->route_expire = (int) $this->eccubeConfig->get('plugin_eccube_2fa_route_customer_expire');
+        $this->tokenLength = (int) $this->eccubeConfig->get('plugin_eccube_2fa_one_time_token_length');
+        $this->tokenActiveDurationSeconds = (int) $this->eccubeConfig->get('plugin_eccube_2fa_one_time_token_expire_after_seconds');
 
         $this->twoFactorAuthConfig = $twoFactorAuthConfigRepository->findOne();
         $this->twoFactorCustomerCookieRepository = $twoFactorCustomerCookieRepository;
@@ -383,28 +396,28 @@ class CustomerTwoFactorAuthService
         }
     }
 
-    public function generateOneTimeToken(): string
+    /**
+     * @throws \Exception - random_int()でphpのランダム機能が見つからないば場合
+     */
+    public function generateOneTimeTokenValue(?int $tokenLengthOverride = null): string
     {
         $token = '';
-        for ($i = 0; $i < 6; $i++) {
-            $token .= (string) random_int(0, 9);
+        for ($i = 0; $i < ($tokenLengthOverride ?? $this->tokenLength); $i++) {
+            $token .= random_int(0, 9);
         }
 
         return $token;
     }
 
-    /***
-     * @param string $input
-     * @return string
+    /**
+     * @throws \Exception
      */
-    public function readOneTimeToken(string $input): string
+    public function generateExpiryDate(?int $tokenActiveDurationSecondsOverride = null): \DateTime
     {
-        $passwordEncoder = $this->hashFactory->getPasswordHasher(Customer::class);
-
-        return $passwordEncoder->hash($input);
+        return (new \DateTime())->add(new \DateInterval('PT'.($tokenActiveDurationSecondsOverride ?? $this->tokenActiveDurationSeconds).'S'));
     }
 
-    public function hashOneTimeToken($token): string
+    public function hashOneTimeToken(string $token): string
     {
         // ハッシュジェネレーターをエンティティに持って来る
         return $this->hashFactory->getPasswordHasher(Customer::class)->hash($token);


### PR DESCRIPTION
> マジックナンバーを解消してほしい
> https://github.com/EC-CUBE/TwoFactorAuthCustomer42/issues/35

について、

■ createTwoFactorAuthOneTimeToken関数名の意味がないため、削除しました。
■ その代わりにCustomerTwoFactorAuthServiceにあるgenerateExpiryDate関数を利用するようにする
   -> コントローラーでモデルのモデルのセッター関数を利用する
■ ワンタイムトークンの桁数をハードコードから定数に変更しました。
■ readOneTimeToken関数とhashOneTimeToken関数は同じことしているため、readOneTimeToken関数を消しました。
■ 有効期限生成コードを整理しました。
