### PR TITLE
管理画面ログアウトできないのを修正

### DIFF
--- a/EventListener/CustomerTwoFactorAuthListener.php
+++ b/EventListener/CustomerTwoFactorAuthListener.php
@@ -205,9 +205,9 @@ class CustomerTwoFactorAuthListener implements EventSubscriberInterface
      */
     public function logoutEvent(LogoutEvent $logoutEvent)
     {
-        $this->customerTwoFactorAuthService->clear2AuthCookies($logoutEvent->getRequest(), $logoutEvent->getResponse());
         $Customer = $this->requestContext->getCurrentUser();
-        if ($Customer !== null) {
+        if ($Customer instanceof Customer) {
+            $this->customerTwoFactorAuthService->clear2AuthCookies($logoutEvent->getRequest(), $logoutEvent->getResponse());
             $this->twoFactorAuthCustomerCookieRepository->deleteByCustomer($Customer);
         }
     }


### PR DESCRIPTION
「EC-CUBE」開発コミュニティにて下記の不具合がありましたため、修正しました。

本人認証プラグインを使用すると管理画面のログアウトボタンでシステムエラーが発生
https://xoops.ec-cube.net/modules/newbb/viewtopic.php?topic_id=28102&forum=9&post_id=111760

ご確認をお願いいたします。
