### PR TITLE
Feat 4.4

### DIFF
--- a/.github/workflows/ab-testing.yml
+++ b/.github/workflows/ab-testing.yml
@@ -25,35 +25,35 @@ jobs:
       - name: Download Plugin
         uses: actions/checkout@master
         with:
-          path: app/Plugin/TwoFactorAuthCustomer42
-      - name: Download Plugin TwoFactorAuthCustomerApp42
+          path: app/Plugin/TwoFactorAuthCustomer44
+      - name: Download Plugin TwoFactorAuthCustomerApp44
         uses: actions/checkout@master
         with:
-          repository: ${{ github.repository_owner }}/TwoFactorAuthCustomerApp42
-          path: app/Plugin/TwoFactorAuthCustomerApp42
-      - name: Download Plugin TwoFactorAuthCustomerSms42
+          repository: ${{ github.repository_owner }}/TwoFactorAuthCustomerApp44
+          path: app/Plugin/TwoFactorAuthCustomerApp44
+      - name: Download Plugin TwoFactorAuthCustomerSms44
         uses: actions/checkout@master
         with:
-          repository: ${{ github.repository_owner }}/TwoFactorAuthCustomerSms42
-          path: app/Plugin/TwoFactorAuthCustomerSms42
+          repository: ${{ github.repository_owner }}/TwoFactorAuthCustomerSms44
+          path: app/Plugin/TwoFactorAuthCustomerSms44
       - name: Sleep for MySQL
         run: sleep 120s
         shell: bash
       - name: Install Plugin
         run: |
-          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.pgsql.yml exec -T ec-cube bin/console eccube:plugin:install --code=TwoFactorAuthCustomer42
+          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.pgsql.yml exec -T ec-cube bin/console eccube:plugin:install --code=TwoFactorAuthCustomer44
           docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.pgsql.yml exec -T ec-cube bin/console cache:clear
-          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.pgsql.yml exec -T ec-cube bin/console eccube:plugin:enable --code=TwoFactorAuthCustomer42
-          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.pgsql.yml exec -T ec-cube bin/console cache:clear
-
-          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.pgsql.yml exec -T ec-cube bin/console eccube:plugin:install --code=TwoFactorAuthCustomerApp42
-          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.pgsql.yml exec -T ec-cube bin/console cache:clear
-          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.pgsql.yml exec -T ec-cube bin/console eccube:plugin:enable --code=TwoFactorAuthCustomerApp42
+          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.pgsql.yml exec -T ec-cube bin/console eccube:plugin:enable --code=TwoFactorAuthCustomer44
           docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.pgsql.yml exec -T ec-cube bin/console cache:clear
 
-          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.pgsql.yml exec -T ec-cube bin/console eccube:plugin:install --code=TwoFactorAuthCustomerSms42
+          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.pgsql.yml exec -T ec-cube bin/console eccube:plugin:install --code=TwoFactorAuthCustomerApp44
           docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.pgsql.yml exec -T ec-cube bin/console cache:clear
-          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.pgsql.yml exec -T ec-cube bin/console eccube:plugin:enable --code=TwoFactorAuthCustomerSms42
+          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.pgsql.yml exec -T ec-cube bin/console eccube:plugin:enable --code=TwoFactorAuthCustomerApp44
+          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.pgsql.yml exec -T ec-cube bin/console cache:clear
+
+          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.pgsql.yml exec -T ec-cube bin/console eccube:plugin:install --code=TwoFactorAuthCustomerSms44
+          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.pgsql.yml exec -T ec-cube bin/console cache:clear
+          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.pgsql.yml exec -T ec-cube bin/console eccube:plugin:enable --code=TwoFactorAuthCustomerSms44
       - name: Wait 30s for the database to load, (as I do not know the databases active state)
         run: sleep 30s
       - name: Start Load EC-CUBE
@@ -220,17 +220,17 @@ jobs:
       - name: Download Plugin
         uses: actions/checkout@master
         with:
-          path: app/Plugin/TwoFactorAuthCustomer42
-      - name: Download Plugin TwoFactorAuthCustomerApp42
+          path: app/Plugin/TwoFactorAuthCustomer44
+      - name: Download Plugin TwoFactorAuthCustomerApp44
         uses: actions/checkout@master
         with:
-          repository: ${{ github.repository_owner }}/TwoFactorAuthCustomerApp42
-          path: app/Plugin/TwoFactorAuthCustomerApp42
-      - name: Download Plugin TwoFactorAuthCustomerSms42
+          repository: ${{ github.repository_owner }}/TwoFactorAuthCustomerApp44
+          path: app/Plugin/TwoFactorAuthCustomerApp44
+      - name: Download Plugin TwoFactorAuthCustomerSms44
         uses: actions/checkout@master
         with:
-          repository: ${{ github.repository_owner }}/TwoFactorAuthCustomerSms42
-          path: app/Plugin/TwoFactorAuthCustomerSms42
+          repository: ${{ github.repository_owner }}/TwoFactorAuthCustomerSms44
+          path: app/Plugin/TwoFactorAuthCustomerSms44
       - name: Start Load EC-CUBE
         run: |
           sed -i 's!APP_ENV: "dev"!APP_ENV: "prod"!g' docker-compose.yml
@@ -240,19 +240,19 @@ jobs:
         shell: bash
       - name: Install Plugin
         run: |
-          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.mysql.yml exec -T ec-cube bin/console eccube:plugin:install --code=TwoFactorAuthCustomer42
+          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.mysql.yml exec -T ec-cube bin/console eccube:plugin:install --code=TwoFactorAuthCustomer44
           docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.mysql.yml exec -T ec-cube bin/console cache:clear
-          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.mysql.yml exec -T ec-cube bin/console eccube:plugin:enable --code=TwoFactorAuthCustomer42
-          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.mysql.yml exec -T ec-cube bin/console cache:clear
-
-          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.mysql.yml exec -T ec-cube bin/console eccube:plugin:install --code=TwoFactorAuthCustomerApp42
-          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.mysql.yml exec -T ec-cube bin/console cache:clear
-          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.mysql.yml exec -T ec-cube bin/console eccube:plugin:enable --code=TwoFactorAuthCustomerApp42
+          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.mysql.yml exec -T ec-cube bin/console eccube:plugin:enable --code=TwoFactorAuthCustomer44
           docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.mysql.yml exec -T ec-cube bin/console cache:clear
 
-          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.mysql.yml exec -T ec-cube bin/console eccube:plugin:install --code=TwoFactorAuthCustomerSms42
+          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.mysql.yml exec -T ec-cube bin/console eccube:plugin:install --code=TwoFactorAuthCustomerApp44
           docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.mysql.yml exec -T ec-cube bin/console cache:clear
-          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.mysql.yml exec -T ec-cube bin/console eccube:plugin:enable --code=TwoFactorAuthCustomerSms42
+          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.mysql.yml exec -T ec-cube bin/console eccube:plugin:enable --code=TwoFactorAuthCustomerApp44
+          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.mysql.yml exec -T ec-cube bin/console cache:clear
+
+          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.mysql.yml exec -T ec-cube bin/console eccube:plugin:install --code=TwoFactorAuthCustomerSms44
+          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.mysql.yml exec -T ec-cube bin/console cache:clear
+          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.mysql.yml exec -T ec-cube bin/console eccube:plugin:enable --code=TwoFactorAuthCustomerSms44
       - name: Wait for 30 seconds for the database to load, (because MySQL is slow to initialize)
         run: sleep 30s
         shell: bash
@@ -438,17 +438,17 @@ jobs:
       - name: Download Plugin
         uses: actions/checkout@master
         with:
-          path: app/Plugin/TwoFactorAuthCustomer42
-      - name: Download Plugin TwoFactorAuthCustomerApp42
+          path: app/Plugin/TwoFactorAuthCustomer44
+      - name: Download Plugin TwoFactorAuthCustomerApp44
         uses: actions/checkout@master
         with:
-          repository: ${{ github.repository_owner }}/TwoFactorAuthCustomerApp42
-          path: app/Plugin/TwoFactorAuthCustomerApp42
-      - name: Download Plugin TwoFactorAuthCustomerSms42
+          repository: ${{ github.repository_owner }}/TwoFactorAuthCustomerApp44
+          path: app/Plugin/TwoFactorAuthCustomerApp44
+      - name: Download Plugin TwoFactorAuthCustomerSms44
         uses: actions/checkout@master
         with:
-          repository: ${{ github.repository_owner }}/TwoFactorAuthCustomerSms42
-          path: app/Plugin/TwoFactorAuthCustomerSms42
+          repository: ${{ github.repository_owner }}/TwoFactorAuthCustomerSms44
+          path: app/Plugin/TwoFactorAuthCustomerSms44
       - name: Start Load EC-CUBE
         run: |
           sed -i 's!APP_ENV: "dev"!APP_ENV: "prod"!g' docker-compose.yml
@@ -458,19 +458,19 @@ jobs:
         shell: bash
       - name: Install Plugin
         run: |
-          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.pgsql.yml exec -T ec-cube bin/console eccube:plugin:install --code=TwoFactorAuthCustomer42
+          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.pgsql.yml exec -T ec-cube bin/console eccube:plugin:install --code=TwoFactorAuthCustomer44
           docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.pgsql.yml exec -T ec-cube bin/console cache:clear
-          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.pgsql.yml exec -T ec-cube bin/console eccube:plugin:enable --code=TwoFactorAuthCustomer42
-          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.pgsql.yml exec -T ec-cube bin/console cache:clear
-
-          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.pgsql.yml exec -T ec-cube bin/console eccube:plugin:install --code=TwoFactorAuthCustomerApp42
-          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.pgsql.yml exec -T ec-cube bin/console cache:clear
-          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.pgsql.yml exec -T ec-cube bin/console eccube:plugin:enable --code=TwoFactorAuthCustomerApp42
+          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.pgsql.yml exec -T ec-cube bin/console eccube:plugin:enable --code=TwoFactorAuthCustomer44
           docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.pgsql.yml exec -T ec-cube bin/console cache:clear
 
-          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.pgsql.yml exec -T ec-cube bin/console eccube:plugin:install --code=TwoFactorAuthCustomerSms42
+          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.pgsql.yml exec -T ec-cube bin/console eccube:plugin:install --code=TwoFactorAuthCustomerApp44
           docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.pgsql.yml exec -T ec-cube bin/console cache:clear
-          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.pgsql.yml exec -T ec-cube bin/console eccube:plugin:enable --code=TwoFactorAuthCustomerSms42
+          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.pgsql.yml exec -T ec-cube bin/console eccube:plugin:enable --code=TwoFactorAuthCustomerApp44
+          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.pgsql.yml exec -T ec-cube bin/console cache:clear
+
+          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.pgsql.yml exec -T ec-cube bin/console eccube:plugin:install --code=TwoFactorAuthCustomerSms44
+          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.pgsql.yml exec -T ec-cube bin/console cache:clear
+          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.pgsql.yml exec -T ec-cube bin/console eccube:plugin:enable --code=TwoFactorAuthCustomerSms44
       - name: Request home page - PGSQL PLUGIN 10000 PRODUCTS
         run: |
           sudo apt-get install apache2-utils
@@ -678,17 +678,17 @@ jobs:
       - name: Download Plugin
         uses: actions/checkout@master
         with:
-          path: app/Plugin/TwoFactorAuthCustomer42
-      - name: Download Plugin TwoFactorAuthCustomerApp42
+          path: app/Plugin/TwoFactorAuthCustomer44
+      - name: Download Plugin TwoFactorAuthCustomerApp44
         uses: actions/checkout@master
         with:
-          repository: ${{ github.repository_owner }}/TwoFactorAuthCustomerApp42
-          path: app/Plugin/TwoFactorAuthCustomerApp42
-      - name: Download Plugin TwoFactorAuthCustomerSms42
+          repository: ${{ github.repository_owner }}/TwoFactorAuthCustomerApp44
+          path: app/Plugin/TwoFactorAuthCustomerApp44
+      - name: Download Plugin TwoFactorAuthCustomerSms44
         uses: actions/checkout@master
         with:
-          repository: ${{ github.repository_owner }}/TwoFactorAuthCustomerSms42
-          path: app/Plugin/TwoFactorAuthCustomerSms42
+          repository: ${{ github.repository_owner }}/TwoFactorAuthCustomerSms44
+          path: app/Plugin/TwoFactorAuthCustomerSms44
       - name: Start Load EC-CUBE
         run: |
           sed -i 's!APP_ENV: "dev"!APP_ENV: "prod"!g' docker-compose.yml
@@ -736,19 +736,19 @@ jobs:
           docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.mysql.yml logs ec-cube
       - name: Install Plugin
         run: |
-          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.mysql.yml exec -T ec-cube bin/console eccube:plugin:install --code=TwoFactorAuthCustomer42
+          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.mysql.yml exec -T ec-cube bin/console eccube:plugin:install --code=TwoFactorAuthCustomer44
           docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.mysql.yml exec -T ec-cube bin/console cache:clear
-          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.mysql.yml exec -T ec-cube bin/console eccube:plugin:enable --code=TwoFactorAuthCustomer42
-          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.mysql.yml exec -T ec-cube bin/console cache:clear
-
-          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.mysql.yml exec -T ec-cube bin/console eccube:plugin:install --code=TwoFactorAuthCustomerApp42
-          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.mysql.yml exec -T ec-cube bin/console cache:clear
-          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.mysql.yml exec -T ec-cube bin/console eccube:plugin:enable --code=TwoFactorAuthCustomerApp42
+          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.mysql.yml exec -T ec-cube bin/console eccube:plugin:enable --code=TwoFactorAuthCustomer44
           docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.mysql.yml exec -T ec-cube bin/console cache:clear
 
-          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.mysql.yml exec -T ec-cube bin/console eccube:plugin:install --code=TwoFactorAuthCustomerSms42
+          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.mysql.yml exec -T ec-cube bin/console eccube:plugin:install --code=TwoFactorAuthCustomerApp44
           docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.mysql.yml exec -T ec-cube bin/console cache:clear
-          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.mysql.yml exec -T ec-cube bin/console eccube:plugin:enable --code=TwoFactorAuthCustomerSms42
+          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.mysql.yml exec -T ec-cube bin/console eccube:plugin:enable --code=TwoFactorAuthCustomerApp44
+          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.mysql.yml exec -T ec-cube bin/console cache:clear
+
+          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.mysql.yml exec -T ec-cube bin/console eccube:plugin:install --code=TwoFactorAuthCustomerSms44
+          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.mysql.yml exec -T ec-cube bin/console cache:clear
+          docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.mysql.yml exec -T ec-cube bin/console eccube:plugin:enable --code=TwoFactorAuthCustomerSms44
       - name: Restart Load EC-CUBE to wait for MySQL
         run: |
           docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.bench.mysql.yml up -d

--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -71,39 +71,39 @@ jobs:
           bin/console doctrine:database:create --env=dev
           bin/console doctrine:schema:create --env=dev
           bin/console eccube:fixtures:load --env=dev
-      - name: Download Plugin TwoFactorAuthCustomer42
+      - name: Download Plugin TwoFactorAuthCustomer44
         uses: actions/checkout@master
         with:
-          path: app/Plugin/TwoFactorAuthCustomer42
-      - name: Download Plugin TwoFactorAuthCustomerApp42
+          path: app/Plugin/TwoFactorAuthCustomer44
+      - name: Download Plugin TwoFactorAuthCustomerApp44
         uses: actions/checkout@master
         with:
-          repository: ${{ github.repository_owner }}/TwoFactorAuthCustomerApp42
-          path: app/Plugin/TwoFactorAuthCustomerApp42
-      - name: Download Plugin TwoFactorAuthCustomerSms42
+          repository: ${{ github.repository_owner }}/TwoFactorAuthCustomerApp44
+          path: app/Plugin/TwoFactorAuthCustomerApp44
+      - name: Download Plugin TwoFactorAuthCustomerSms44
         uses: actions/checkout@master
         with:
-          repository: ${{ github.repository_owner }}/TwoFactorAuthCustomerSms42
-          path: app/Plugin/TwoFactorAuthCustomerSms42
+          repository: ${{ github.repository_owner }}/TwoFactorAuthCustomerSms44
+          path: app/Plugin/TwoFactorAuthCustomerSms44
       - name: Install Plugins
         env:
           APP_ENV: ${{ matrix.app_env }}
           DATABASE_URL: ${{ matrix.database_url }}
           DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
         run: |
-          bin/console eccube:plugin:install --code=TwoFactorAuthCustomer42
+          bin/console eccube:plugin:install --code=TwoFactorAuthCustomer44
           bin/console cache:clear
-          bin/console eccube:plugin:enable --code=TwoFactorAuthCustomer42
-          bin/console cache:clear
-
-          bin/console eccube:plugin:install --code=TwoFactorAuthCustomerApp42
-          bin/console cache:clear
-          bin/console eccube:plugin:enable --code=TwoFactorAuthCustomerApp42
+          bin/console eccube:plugin:enable --code=TwoFactorAuthCustomer44
           bin/console cache:clear
 
-          bin/console eccube:plugin:install --code=TwoFactorAuthCustomerSms42
+          bin/console eccube:plugin:install --code=TwoFactorAuthCustomerApp44
           bin/console cache:clear
-          bin/console eccube:plugin:enable --code=TwoFactorAuthCustomerSms42
+          bin/console eccube:plugin:enable --code=TwoFactorAuthCustomerApp44
+          bin/console cache:clear
+
+          bin/console eccube:plugin:install --code=TwoFactorAuthCustomerSms44
+          bin/console cache:clear
+          bin/console eccube:plugin:enable --code=TwoFactorAuthCustomerSms44
 
       - name: setup-chromedriver
         uses: nanasess/setup-chromedriver@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: CI for TwoFactorAuthCustomer42
+name: CI for TwoFactorAuthCustomer44
 on:
   push:
     branches:
@@ -17,19 +17,15 @@ on:
 jobs:
   run-on-linux:
     name: Run on Linux
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
-        eccube_version: [ '4.2','4.3' ]
-        php: [ '7.4', '8.0', '8.1','8.2', '8.3' ]
-        db: [ 'mysql', 'mysql8', 'pgsql' ]
-        plugin_code: [ 'TwoFactorAuthCustomer42' ]
+        eccube_version: [ '4.4' ]
+        php: [ '8.2', '8.3', '8.4', '8.5' ]
+        db: [ 'mysql8', 'pgsql' ]
+        plugin_code: [ 'TwoFactorAuthCustomer44' ]
         include:
-          - db: mysql
-            database_url: mysql://root:password@127.0.0.1:3306/eccube_db
-            database_server_version: 5.7
-            database_charset: utf8mb4
           - db: mysql8
             database_url: mysql://root:password@127.0.0.1:3308/eccube_db
             database_server_version: 8
@@ -38,24 +34,7 @@ jobs:
             database_url: postgres://postgres:password@127.0.0.1:5432/eccube_db
             database_server_version: 14
             database_charset: utf8
-        exclude:
-          -   eccube_version: 4.2
-              php: 8.2
-          -   eccube_version: 4.2
-              php: 8.3
-          -   eccube_version: 4.3
-              php: 7.4
-          -   eccube_version: 4.3
-              php: 8.0
     services:
-      mysql:
-        image: mysql:5.7
-        env:
-          MYSQL_ROOT_PASSWORD: password
-          MYSQL_DATABASE: ${{ matrix.dbname }}
-        ports:
-          - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
       mysql8:
         image: mysql:8
         env:
@@ -81,7 +60,7 @@ jobs:
           - 1025:1025
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: nanasess/setup-php@master
@@ -93,17 +72,8 @@ jobs:
           PLUGIN_CODE: ${{ matrix.plugin_code }}
         run: |
           tar cvzf ${GITHUB_WORKSPACE}/${PLUGIN_CODE}.tar.gz ./*
-
-      - name: Setup mock-package-api
-        env:
-          PLUGIN_CODE: ${{ matrix.plugin_code }}
-        run: |
-          mkdir -p /tmp/repos
-          cp ${GITHUB_WORKSPACE}/${PLUGIN_CODE}.tar.gz /tmp/repos/${PLUGIN_CODE}.tgz
-          docker run --name package-api -d -v /tmp/repos:/repos -e MOCK_REPO_DIR=/repos -p 8080:8080 eccube/mock-package-api:composer2
-
       - name: Checkout EC-CUBE
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: 'EC-CUBE/ec-cube'
           ref: ${{ matrix.eccube_version }}
@@ -112,8 +82,8 @@ jobs:
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
-      - uses: actions/cache@v1
+          echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -121,7 +91,9 @@ jobs:
             ${{ runner.os }}-composer-
       - name: Install to composer
         working-directory: 'ec-cube'
-        run: composer install --no-interaction -o --apcu-autoloader
+        # Symfony 7.4 の symfony/cache が ext-redis <6.1 と衝突するが、ランナーには
+        # 古い php-redis(5.3.7) が入っている。本プラグイン/本体テストは redis 未使用のため無視する。
+        run: composer install --no-interaction -o --apcu-autoloader --ignore-platform-req=ext-redis
 
       - name: Setup EC-CUBE
         env:
@@ -130,7 +102,6 @@ jobs:
           DATABASE_URL: ${{ matrix.database_url }}
           DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
           DATABASE_CHARSET: ${{ matrix.database_charset }}
-          ECCUBE_PACKAGE_API_URL: 'http://127.0.0.1:8080'
         working-directory: 'ec-cube'
         run: |
           bin/console doctrine:database:create
@@ -144,12 +115,28 @@ jobs:
           DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
           DATABASE_CHARSET: ${{ matrix.database_charset }}
           PLUGIN_CODE: ${{ matrix.plugin_code }}
-          ECCUBE_PACKAGE_API_URL: 'http://127.0.0.1:8080'
         working-directory: 'ec-cube'
         run: |
-          bin/console eccube:composer:require ec-cube/twofactorauthcustomer42
-          bin/console cache:clear --no-warmup
+          bin/console eccube:plugin:install --code=${PLUGIN_CODE} --path=${GITHUB_WORKSPACE}/${PLUGIN_CODE}.tar.gz
           bin/console eccube:plugin:enable --code=${PLUGIN_CODE}
+          bin/console cache:clear --no-warmup
+      - name: Run PHPUnit
+        env:
+          APP_ENV: 'test'
+          APP_DEBUG: 0
+          DATABASE_URL: ${{ matrix.database_url }}
+          DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
+          DATABASE_CHARSET: ${{ matrix.database_charset }}
+          PLUGIN_CODE: ${{ matrix.plugin_code }}
+        working-directory: 'ec-cube'
+        run: |
+          # 有効化したプラグインのルーティングはコンテナのコンパイル時に確定する。
+          # phpunit プロセスでの遅延コンパイルに任せると DB/タイミングで有効プラグイン一覧を
+          # 取りこぼし RouteNotFound になることがあるため、クリーンなプロセスで warmup して確定させる。
+          bin/console cache:clear --no-warmup
+          bin/console cache:warmup
+          ./vendor/bin/phpunit -c app/Plugin/${PLUGIN_CODE}/phpunit.xml.dist app/Plugin/${PLUGIN_CODE}/Tests
+
       - name: Disable Plugin
         working-directory: 'ec-cube'
         env:
@@ -159,7 +146,6 @@ jobs:
           DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
           DATABASE_CHARSET: ${{ matrix.database_charset }}
           PLUGIN_CODE: ${{ matrix.plugin_code }}
-          ECCUBE_PACKAGE_API_URL: 'http://127.0.0.1:8080'
         run: bin/console eccube:plugin:disable --code=${PLUGIN_CODE}
 
       - name: Uninstall Plugin
@@ -170,6 +156,79 @@ jobs:
           DATABASE_SERVER_VERSION: ${{ matrix.database_server_version }}
           DATABASE_CHARSET: ${{ matrix.database_charset }}
           PLUGIN_CODE: ${{ matrix.plugin_code }}
-          ECCUBE_PACKAGE_API_URL: 'http://127.0.0.1:8080'
         working-directory: 'ec-cube'
         run: bin/console eccube:plugin:uninstall --code=${PLUGIN_CODE}
+
+  static-analysis:
+    name: Static Analysis
+    runs-on: ubuntu-24.04
+    # 静的解析は DB 種別に依存しないため、SQLite 1 構成で一度だけ実行する。
+    # （php-cs-fixer / rector は DB 不要だが、phpstan は objectManagerLoader が
+    #   カーネルを起動し EccubeExtension が dtb_plugin を読むため本体+DBが必要）
+    env:
+      PLUGIN_CODE: TwoFactorAuthCustomer44
+      APP_ENV: 'test'
+      APP_DEBUG: 0
+      DATABASE_URL: 'sqlite:///var/eccube.db'
+      DATABASE_SERVER_VERSION: 3
+      DATABASE_CHARSET: 'utf8'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: nanasess/setup-php@master
+        with:
+          php-version: '8.5'
+
+      - name: Archive Plugin
+        run: |
+          tar cvzf ${GITHUB_WORKSPACE}/${PLUGIN_CODE}.tar.gz ./*
+      - name: Checkout EC-CUBE
+        uses: actions/checkout@v4
+        with:
+          repository: 'EC-CUBE/ec-cube'
+          ref: '4.4'
+          path: 'ec-cube'
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+      - name: Install to composer
+        working-directory: 'ec-cube'
+        run: composer install --no-interaction -o --apcu-autoloader --ignore-platform-req=ext-redis
+
+      - name: Setup EC-CUBE
+        working-directory: 'ec-cube'
+        run: |
+          bin/console doctrine:database:create
+          bin/console doctrine:schema:create
+          # プラグイン有効化時に DeviceType 等のマスタデータを参照するため fixtures を投入する
+          bin/console eccube:fixtures:load
+      - name: Setup Plugin
+        working-directory: 'ec-cube'
+        run: |
+          bin/console eccube:plugin:install --code=${PLUGIN_CODE} --path=${GITHUB_WORKSPACE}/${PLUGIN_CODE}.tar.gz
+          bin/console eccube:plugin:enable --code=${PLUGIN_CODE}
+          bin/console cache:clear --no-warmup
+
+      - name: Run php-cs-fixer
+        working-directory: 'ec-cube'
+        run: ./vendor/bin/php-cs-fixer fix --config=app/Plugin/${PLUGIN_CODE}/Resource/.php-cs-fixer.dist.php --dry-run --diff
+
+      - name: Run Rector
+        working-directory: 'ec-cube'
+        run: ./vendor/bin/rector process --config=app/Plugin/${PLUGIN_CODE}/Resource/rector.php --dry-run
+
+      - name: Run PHPStan
+        working-directory: 'ec-cube'
+        run: |
+          bin/console cache:clear --no-warmup
+          ./vendor/bin/phpstan analyse -c app/Plugin/${PLUGIN_CODE}/phpstan.neon.dist --no-progress

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,19 +8,23 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Packaging
         working-directory: ../
         run: |
           rm -rf $GITHUB_WORKSPACE/.github
+          # 開発・テスト用ファイルは配布パッケージに含めない
+          rm -rf $GITHUB_WORKSPACE/docker-compose*.yml $GITHUB_WORKSPACE/dockerbuild
           rm -rf $GITHUB_WORKSPACE/doc
+          rm -f $GITHUB_WORKSPACE/CLAUDE.md $GITHUB_WORKSPACE/phpstan.neon.dist
+          rm -f $GITHUB_WORKSPACE/Resource/rector.php "$GITHUB_WORKSPACE/Resource/.php-cs-fixer.dist.php"
           find $GITHUB_WORKSPACE -name "dummy" -delete
           find $GITHUB_WORKSPACE -name ".git*" -and ! -name ".gitkeep" -print0 | xargs -0 rm -rf
           chmod -R o+w $GITHUB_WORKSPACE
           cd $GITHUB_WORKSPACE
           tar cvzf ../${{ github.event.repository.name }}-${{ github.event.release.tag_name }}.tar.gz ./*
       - name: Upload binaries to release of TGZ
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@v1-release
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ${{ runner.workspace }}/${{ github.event.repository.name }}-${{ github.event.release.tag_name }}.tar.gz

--- a/Controller/Admin/ConfigController.php
+++ b/Controller/Admin/ConfigController.php
@@ -11,42 +11,36 @@
  * file that was distributed with this source code.
  */
 
-namespace Plugin\TwoFactorAuthCustomer42\Controller\Admin;
+namespace Plugin\TwoFactorAuthCustomer44\Controller\Admin;
 
 use Eccube\Controller\AbstractController;
-use Plugin\TwoFactorAuthCustomer42\Form\Type\TwoFactorAuthConfigType;
-use Plugin\TwoFactorAuthCustomer42\Repository\TwoFactorAuthConfigRepository;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Plugin\TwoFactorAuthCustomer44\Form\Type\TwoFactorAuthConfigType;
+use Plugin\TwoFactorAuthCustomer44\Repository\TwoFactorAuthConfigRepository;
+use Symfony\Bridge\Twig\Attribute\Template;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 /**
- * Class SmsController
+ * Class ConfigController
  */
 class ConfigController extends AbstractController
 {
     /**
-     * @var TwoFactorAuthConfigRepository
-     */
-    private $smsConfigRepository;
-
-    /**
      * ConfigController constructor.
      */
-    public function __construct(TwoFactorAuthConfigRepository $smsConfigRepository)
-    {
-        $this->smsConfigRepository = $smsConfigRepository;
+    public function __construct(
+        private readonly TwoFactorAuthConfigRepository $smsConfigRepository,
+    ) {
     }
 
     /**
-     * @Route("/%eccube_admin_route%/two_factor_auth_customer42/config", name="two_factor_auth_customer42_admin_config", methods={"GET", "POST"})
-     * @Template("TwoFactorAuthCustomer42/Resource/template/admin/config.twig")
-     *
      * @param Request $request
      *
      * @return RedirectResponse|array
      */
+    #[Route(path: '/%eccube_admin_route%/two_factor_auth_customer44/config', name: 'two_factor_auth_customer44_admin_config', methods: ['GET', 'POST'])]
+    #[Template('@TwoFactorAuthCustomer44/admin/config.twig')]
     public function index(Request $request)
     {
         // 設定情報、フォーム情報を取得
@@ -72,14 +66,14 @@ class ConfigController extends AbstractController
 
             // フォームの入力データを保存
             $this->entityManager->persist($SmsConfig);
-            $this->entityManager->flush($SmsConfig);
+            $this->entityManager->flush();
 
             // 完了メッセージを表示
             log_info('config', ['status' => 'Success']);
             $this->addSuccess('プラグインの設定を保存しました。', 'admin');
 
             // 設定画面にリダイレクト
-            return $this->redirectToRoute('two_factor_auth_customer42_admin_config');
+            return $this->redirectToRoute('two_factor_auth_customer44_admin_config');
         }
 
         return [

--- a/Controller/CustomerPersonalValidationController.php
+++ b/Controller/CustomerPersonalValidationController.php
@@ -11,21 +11,20 @@
  * file that was distributed with this source code.
  */
 
-namespace Plugin\TwoFactorAuthCustomer42\Controller;
+namespace Plugin\TwoFactorAuthCustomer44\Controller;
 
-use Eccube\Common\Constant;
 use Eccube\Controller\AbstractController;
 use Eccube\Entity\Customer;
 use Eccube\Repository\CustomerRepository;
-use Plugin\TwoFactorAuthCustomer42\Form\Type\TwoFactorAuthPhoneNumberTypeCustomer;
-use Plugin\TwoFactorAuthCustomer42\Form\Type\TwoFactorAuthSmsTypeCustomer;
-use Plugin\TwoFactorAuthCustomer42\Service\CustomerTwoFactorAuthService;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Plugin\TwoFactorAuthCustomer44\Form\Type\TwoFactorAuthPhoneNumberTypeCustomer;
+use Plugin\TwoFactorAuthCustomer44\Form\Type\TwoFactorAuthSmsTypeCustomer;
+use Plugin\TwoFactorAuthCustomer44\Service\CustomerTwoFactorAuthService;
+use Symfony\Bridge\Twig\Attribute\Template;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Twig\Environment;
 use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
@@ -37,51 +36,31 @@ use Twilio\Rest\Api\V2010\Account\MessageInstance;
 class CustomerPersonalValidationController extends AbstractController
 {
     /**
-     * @var CustomerRepository
-     */
-    protected CustomerRepository $customerRepository;
-
-    /**
-     * @var CustomerTwoFactorAuthService
-     */
-    protected CustomerTwoFactorAuthService $customerTwoFactorAuthService;
-
-    /**
-     * @var Environment
-     */
-    protected Environment $twig;
-    private RateLimiterFactory $deviceAuthRequestEmailLimiter;
-
-    /**
      * TwoFactorAuthCustomerController constructor.
      *
-     * @param CustomerRepository $customerRepository ,
-     * @param CustomerTwoFactorAuthService $customerTwoFactorAuthService ,
+     * @param RateLimiterFactory $deviceAuthRequestEmailLimiter
+     * @param CustomerRepository $customerRepository
+     * @param CustomerTwoFactorAuthService $customerTwoFactorAuthService
      * @param Environment $twig
      */
     public function __construct(
-        RateLimiterFactory $deviceAuthRequestEmailLimiter,
-        CustomerRepository $customerRepository,
-        CustomerTwoFactorAuthService $customerTwoFactorAuthService,
-        Environment $twig
+        private RateLimiterFactory $deviceAuthRequestEmailLimiter,
+        protected CustomerRepository $customerRepository,
+        protected CustomerTwoFactorAuthService $customerTwoFactorAuthService,
+        protected Environment $twig,
     ) {
-        $this->customerRepository = $customerRepository;
-        $this->customerTwoFactorAuthService = $customerTwoFactorAuthService;
-        $this->twig = $twig;
-        $this->deviceAuthRequestEmailLimiter = $deviceAuthRequestEmailLimiter;
     }
 
     /**
      * (デバイス認証時)デバイス認証ワンタイムトークン入力画面.
      *
-     * @Route("/two_factor_auth/device_auth/input_onetime/{secret_key}", name="plg_customer_2fa_device_auth_input_onetime", requirements={"secret_key" = "^[a-zA-Z0-9]+$"}, methods={"GET", "POST"})
-     * @Template("TwoFactorAuthCustomer42/Resource/template/default/device_auth/input.twig")
-     *
      * @param Request $request
-     * @param $secret_key
+     * @param string $secret_key
      *
      * @return array|RedirectResponse
      */
+    #[Route(path: '/two_factor_auth/device_auth/input_onetime/{secret_key}', name: 'plg_customer_2fa_device_auth_input_onetime', requirements: ['secret_key' => '^[a-zA-Z0-9]+$'], methods: ['GET', 'POST'])]
+    #[Template('@TwoFactorAuthCustomer44/default/device_auth/input.twig')]
     public function deviceAuthInputOneTime(Request $request, $secret_key)
     {
         if ($this->isGranted('ROLE_USER')) {
@@ -155,11 +134,8 @@ class CustomerPersonalValidationController extends AbstractController
     /**
      * (デバイス認証時)デバイス認証 送信先入力画面.
      *
-     * @Route("/two_factor_auth/device_auth/send_onetime/{secret_key}", name="plg_customer_2fa_device_auth_send_onetime", requirements={"secret_key" = "^[a-zA-Z0-9]+$"}, methods={"GET", "POST"})
-     * @Template("TwoFactorAuthCustomer42/Resource/template/default/device_auth/send.twig")
-     *
      * @param Request $request
-     * @param $secret_key
+     * @param string $secret_key
      *
      * @return array|RedirectResponse
      *
@@ -169,6 +145,8 @@ class CustomerPersonalValidationController extends AbstractController
      * @throws SyntaxError
      * @throws TwilioException
      */
+    #[Route(path: '/two_factor_auth/device_auth/send_onetime/{secret_key}', name: 'plg_customer_2fa_device_auth_send_onetime', requirements: ['secret_key' => '^[a-zA-Z0-9]+$'], methods: ['GET', 'POST'])]
+    #[Template('@TwoFactorAuthCustomer44/default/device_auth/send.twig')]
     public function deviceAuthSendOneTime(Request $request, $secret_key)
     {
         if ($this->isGranted('ROLE_USER')) {
@@ -228,10 +206,10 @@ class CustomerPersonalValidationController extends AbstractController
     /**
      * デバイス認証用のワンタイムトークンチェック.
      *
-     * @param $Customer
-     * @param $token
+     * @param Customer $Customer
+     * @param string $token
      *
-     * @return boolean
+     * @return bool
      */
     private function checkDeviceToken($Customer, $token): bool
     {
@@ -271,7 +249,7 @@ class CustomerPersonalValidationController extends AbstractController
         $this->entityManager->flush();
 
         // ワンタイムトークン送信メッセージをレンダリング
-        $twig = 'TwoFactorAuthCustomer42/Resource/template/default/sms/onetime_message.twig';
+        $twig = '@TwoFactorAuthCustomer44/default/sms/onetime_message.twig';
         $body = $this->twig->render($twig, [
             'Customer' => $Customer,
             'token' => $token,

--- a/Controller/TwoFactorAuthCustomerController.php
+++ b/Controller/TwoFactorAuthCustomerController.php
@@ -11,57 +11,39 @@
  * file that was distributed with this source code.
  */
 
-namespace Plugin\TwoFactorAuthCustomer42\Controller;
+namespace Plugin\TwoFactorAuthCustomer44\Controller;
 
 use Eccube\Controller\AbstractController;
 use Eccube\Entity\Customer;
 use Eccube\Repository\CustomerRepository;
-use Plugin\TwoFactorAuthCustomer42\Form\Type\TwoFactorAuthTypeCustomer;
-use Plugin\TwoFactorAuthCustomer42\Service\CustomerTwoFactorAuthService;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Plugin\TwoFactorAuthCustomer44\Form\Type\TwoFactorAuthTypeCustomer;
+use Plugin\TwoFactorAuthCustomer44\Service\CustomerTwoFactorAuthService;
+use Symfony\Bridge\Twig\Attribute\Template;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Twig\Environment;
 
 class TwoFactorAuthCustomerController extends AbstractController
 {
     /**
-     * @var CustomerRepository
-     */
-    protected CustomerRepository $customerRepository;
-
-    /**
-     * @var CustomerTwoFactorAuthService
-     */
-    protected CustomerTwoFactorAuthService $customerTwoFactorAuthService;
-    /**
-     * @var Environment
-     */
-    protected Environment $twig;
-
-    /**
      * TwoFactorAuthCustomerController constructor.
      *
-     * @param CustomerRepository $customerRepository ,
-     * @param CustomerTwoFactorAuthService $customerTwoFactorAuthService ,
+     * @param CustomerRepository $customerRepository
+     * @param CustomerTwoFactorAuthService $customerTwoFactorAuthService
      * @param Environment $twig
      */
     public function __construct(
-        CustomerRepository $customerRepository,
-        CustomerTwoFactorAuthService $customerTwoFactorAuthService,
-        Environment $twig
+        protected CustomerRepository $customerRepository,
+        protected CustomerTwoFactorAuthService $customerTwoFactorAuthService,
+        protected Environment $twig,
     ) {
-        $this->customerRepository = $customerRepository;
-        $this->customerTwoFactorAuthService = $customerTwoFactorAuthService;
-        $this->twig = $twig;
     }
 
     /**
      * (ログイン時)二段階認証設定（選択）画面.
-     *
-     * @Route("/mypage/two_factor_auth/select_type", name="plg_customer_2fa_auth_type_select", methods={"GET", "POST"})
-     * @Template("TwoFactorAuthCustomer42/Resource/template/default/tfa/select_type.twig")
      */
+    #[Route(path: '/mypage/two_factor_auth/select_type', name: 'plg_customer_2fa_auth_type_select', methods: ['GET', 'POST'])]
+    #[Template('@TwoFactorAuthCustomer44/default/tfa/select_type.twig')]
     public function selectAuthType(Request $request)
     {
         if ($this->isTwoFactorAuthed()) {
@@ -106,7 +88,7 @@ class TwoFactorAuthCustomerController extends AbstractController
     /**
      * 認証済みか否か.
      *
-     * @return boolean
+     * @return bool
      */
     protected function isTwoFactorAuthed(): bool
     {

--- a/Entity/BaseInfoTrait.php
+++ b/Entity/BaseInfoTrait.php
@@ -11,60 +11,43 @@
  * file that was distributed with this source code.
  */
 
-namespace Plugin\TwoFactorAuthCustomer42\Entity;
+namespace Plugin\TwoFactorAuthCustomer44\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
-use Eccube\Annotation\EntityExtension;
+use Eccube\Attribute\EntityExtension;
+use Eccube\Entity\BaseInfo;
 
-/**
- * @EntityExtension("Eccube\Entity\BaseInfo")
- */
+#[EntityExtension(BaseInfo::class)]
 trait BaseInfoTrait
 {
     /**
      * 2段階認証機能の利用
-     *
-     * @var bool
-     *
-     * @ORM\Column(name="two_factor_auth_use", type="boolean", nullable=false, options={"default":false})
      */
-    private bool $two_factor_auth_use;
-    /**
-     * SMS通知の設定
-     *
-     * @var bool
-     *
-     * @ORM\Column(name="option_activate_device", type="boolean", nullable=false, options={"default":false})
-     */
-    private bool $option_activate_device;
+    #[ORM\Column(name: 'two_factor_auth_use', type: Types::BOOLEAN, nullable: false, options: ['default' => false])]
+    private bool $two_factor_auth_use = false;
 
     /**
-     * @return bool
+     * SMS通知の設定
      */
+    #[ORM\Column(name: 'option_activate_device', type: Types::BOOLEAN, nullable: false, options: ['default' => false])]
+    private bool $option_activate_device = false;
+
     public function isTwoFactorAuthUse(): bool
     {
         return $this->two_factor_auth_use;
     }
 
-    /**
-     * @param bool $two_factor_auth_use
-     */
     public function setTwoFactorAuthUse(bool $two_factor_auth_use): void
     {
         $this->two_factor_auth_use = $two_factor_auth_use;
     }
 
-    /**
-     * @return bool
-     */
     public function isOptionActivateDevice(): bool
     {
         return $this->option_activate_device;
     }
 
-    /**
-     * @param bool $option_activate_device
-     */
     public function setOptionActivateDevice(bool $option_activate_device): void
     {
         $this->option_activate_device = $option_activate_device;

--- a/Entity/CustomerTrait.php
+++ b/Entity/CustomerTrait.php
@@ -11,82 +11,50 @@
  * file that was distributed with this source code.
  */
 
-namespace Plugin\TwoFactorAuthCustomer42\Entity;
+namespace Plugin\TwoFactorAuthCustomer44\Entity;
 
 use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
-use Eccube\Annotation\EntityExtension;
+use Eccube\Attribute\EntityExtension;
+use Eccube\Entity\Customer;
 
-/**
- * @EntityExtension("Eccube\Entity\Customer")
- */
+#[EntityExtension(Customer::class)]
 trait CustomerTrait
 {
-    /**
-     * @var ?string
-     *
-     * @ORM\Column(name="device_auth_one_time_token", type="string", length=255, nullable=true)
-     */
+    #[ORM\Column(name: 'device_auth_one_time_token', type: Types::STRING, length: 255, nullable: true)]
     private ?string $device_auth_one_time_token = null;
 
-    /**
-     * @var \DateTime|null
-     *
-     * @ORM\Column(name="device_auth_one_time_token_expire", type="datetimetz", nullable=true)
-     */
-    private $device_auth_one_time_token_expire;
+    #[ORM\Column(name: 'device_auth_one_time_token_expire', type: Types::DATETIMETZ_MUTABLE, nullable: true)]
+    private ?\DateTime $device_auth_one_time_token_expire = null;
 
-    /**
-     * @var boolean
-     *
-     * @ORM\Column(name="device_authed", type="boolean", nullable=false, options={"default":false})
-     */
+    #[ORM\Column(name: 'device_authed', type: Types::BOOLEAN, nullable: false, options: ['default' => false])]
     private bool $device_authed = false;
 
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="device_authed_phone_number", type="string", length=14, nullable=true)
-     */
+    #[ORM\Column(name: 'device_authed_phone_number', type: Types::STRING, length: 14, nullable: true)]
     private ?string $device_authed_phone_number = null;
 
     /**
      * 2段階認証機能の設定
-     *
-     * @var int|null
-     *
-     * @ORM\Column(name="two_factor_auth_type", type="integer", nullable=true)
      */
+    #[ORM\Column(name: 'two_factor_auth_type', type: Types::INTEGER, nullable: true)]
     private ?int $two_factor_auth_type = null;
 
-    /**
-     * @var TwoFactorAuthType
-     *
-     * @ORM\ManyToOne(targetEntity="\Plugin\TwoFactorAuthCustomer42\Entity\TwoFactorAuthType")
-     * @ORM\JoinColumns({
-     *   @ORM\JoinColumn(name="two_factor_auth_type_id", referencedColumnName="id")
-     * })
-     */
-    private $TwoFactorAuthType = null;
+    #[ORM\ManyToOne(targetEntity: TwoFactorAuthType::class)]
+    #[ORM\JoinColumn(name: 'two_factor_auth_type_id', referencedColumnName: 'id')]
+    private ?TwoFactorAuthType $TwoFactorAuthType = null;
 
     /**
-     * @var Collection
-     *
-     * @ORM\OneToMany(targetEntity="\Plugin\TwoFactorAuthCustomer42\Entity\TwoFactorAuthCustomerCookie", mappedBy="Customer")
+     * @var Collection<int, TwoFactorAuthCustomerCookie>|null
      */
+    #[ORM\OneToMany(targetEntity: TwoFactorAuthCustomerCookie::class, mappedBy: 'Customer')]
     private $TwoFactorAuthCustomerCookies;
 
-    /**
-     * @return string
-     */
     public function getDeviceAuthOneTimeToken(): ?string
     {
         return $this->device_auth_one_time_token;
     }
 
-    /**
-     * @param string|null $device_auth_one_time_token
-     */
     public function setDeviceAuthOneTimeToken(?string $device_auth_one_time_token): void
     {
         $this->device_auth_one_time_token = $device_auth_one_time_token;
@@ -94,18 +62,14 @@ trait CustomerTrait
 
     /**
      * Get resetExpire.
-     *
-     * @return \DateTime|null
      */
-    public function getDeviceAuthOneTimeTokenExpire()
+    public function getDeviceAuthOneTimeTokenExpire(): ?\DateTime
     {
         return $this->device_auth_one_time_token_expire;
     }
 
     /**
      * Set oneTimeTokenExpire.
-     *
-     * @param \DateTime|null $resetExpire
      *
      * @return Customer
      */
@@ -116,44 +80,30 @@ trait CustomerTrait
         return $this;
     }
 
-    /**
-     * @return bool
-     */
     public function isDeviceAuthed(): bool
     {
         return $this->device_authed;
     }
 
-    /**
-     * @param bool $device_authed
-     */
     public function setDeviceAuthed(bool $device_authed): void
     {
         $this->device_authed = $device_authed;
     }
 
-    /**
-     * @return string
-     */
     public function getDeviceAuthedPhoneNumber(): ?string
     {
         return $this->device_authed_phone_number;
     }
 
-    /**
-     * @param string|null $device_authed_phone_number
-     */
     public function setDeviceAuthedPhoneNumber(?string $device_authed_phone_number): void
     {
         $this->device_authed_phone_number = $device_authed_phone_number;
     }
 
     /**
-     * Get sex.
-     *
-     * @return TwoFactorAuthType|null
+     * Get two-factor auth type.
      */
-    public function getTwoFactorAuthType()
+    public function getTwoFactorAuthType(): ?TwoFactorAuthType
     {
         return $this->TwoFactorAuthType;
     }
@@ -161,26 +111,20 @@ trait CustomerTrait
     /**
      * Set two-factor auth type.
      *
-     * @param TwoFactorAuthType|null $twoFactorAuthType
+     * @return $this
      */
-    public function setTwoFactorAuthType(TwoFactorAuthType $twoFactorAuthType = null)
+    public function setTwoFactorAuthType(?TwoFactorAuthType $twoFactorAuthType = null)
     {
         $this->TwoFactorAuthType = $twoFactorAuthType;
 
         return $this;
     }
 
-    /**
-     * @return Collection
-     */
     public function getTwoFactorAuthCustomerCookies(): Collection
     {
         return $this->TwoFactorAuthCustomerCookies;
     }
 
-    /**
-     * @param Collection $TwoFactorAuthCustomerCookies
-     */
     public function setTwoFactorAuthCustomerCookies(Collection $TwoFactorAuthCustomerCookies): void
     {
         $this->TwoFactorAuthCustomerCookies = $TwoFactorAuthCustomerCookies;

--- a/Entity/TwoFactorAuthConfig.php
+++ b/Entity/TwoFactorAuthConfig.php
@@ -11,63 +11,43 @@
  * file that was distributed with this source code.
  */
 
-namespace Plugin\TwoFactorAuthCustomer42\Entity;
+namespace Plugin\TwoFactorAuthCustomer44\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Eccube\Entity\AbstractEntity;
+use Plugin\TwoFactorAuthCustomer44\Repository\TwoFactorAuthConfigRepository;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
-use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * TwoFactorConfig
- *
- * @ORM\Table(name="plg_two_factor_auth_config")
- * @ORM\InheritanceType("SINGLE_TABLE")
- * @ORM\DiscriminatorColumn(name="discriminator_type", type="string", length=255)
- * @ORM\HasLifecycleCallbacks()
- * @ORM\Entity(repositoryClass="Plugin\TwoFactorAuthCustomer42\Repository\TwoFactorAuthConfigRepository")
- * @UniqueEntity("id")
  */
+#[ORM\Table(name: 'plg_two_factor_auth_config')]
+#[ORM\InheritanceType('SINGLE_TABLE')]
+#[ORM\DiscriminatorColumn(name: 'discriminator_type', type: Types::STRING, length: 255)]
+#[ORM\HasLifecycleCallbacks]
+#[ORM\Entity(repositoryClass: TwoFactorAuthConfigRepository::class)]
+#[UniqueEntity('id')]
 class TwoFactorAuthConfig extends AbstractEntity
 {
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="id", type="integer", options={"unsigned":true})
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="IDENTITY")
-     */
-    private $id;
+    #[ORM\Column(name: 'id', type: Types::INTEGER, options: ['unsigned' => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    private ?int $id = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="api_key", type="string", nullable=true, length=200)
-     */
-    private $api_key = null;
+    #[ORM\Column(name: 'api_key', type: Types::STRING, nullable: true, length: 200)]
+    private ?string $api_key = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="api_secret", type="string", nullable=true, length=200)
-     */
-    private $api_secret = null;
+    #[ORM\Column(name: 'api_secret', type: Types::STRING, nullable: true, length: 200)]
+    private ?string $api_secret = null;
 
-    private $plain_api_secret;
+    private ?string $plain_api_secret = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="from_phone_number", type="string", nullable=true, length=200)
-     */
-    private $from_phone_number = null;
+    #[ORM\Column(name: 'from_phone_number', type: Types::STRING, nullable: true, length: 200)]
+    private ?string $from_phone_number = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="include_routes", type="text", nullable=true)
-     */
-    private $include_routes = null;
+    #[ORM\Column(name: 'include_routes', type: Types::TEXT, nullable: true)]
+    private ?string $include_routes = null;
 
     /**
      * Constructor.
@@ -78,20 +58,16 @@ class TwoFactorAuthConfig extends AbstractEntity
 
     /**
      * Get id.
-     *
-     * @return int
      */
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }
 
     /**
      * Get api_key.
-     *
-     * @return string
      */
-    public function getApiKey()
+    public function getApiKey(): ?string
     {
         return $this->api_key;
     }
@@ -99,11 +75,9 @@ class TwoFactorAuthConfig extends AbstractEntity
     /**
      * Set api_key.
      *
-     * @param string $apiKey
-     *
-     * @return TwoFactorAuthConfig
+     * @return $this
      */
-    public function setApiKey($apiKey)
+    public function setApiKey(?string $apiKey): self
     {
         $this->api_key = $apiKey;
 
@@ -112,10 +86,8 @@ class TwoFactorAuthConfig extends AbstractEntity
 
     /**
      * Get api_secret.
-     *
-     * @return string
      */
-    public function getApiSecret()
+    public function getApiSecret(): ?string
     {
         return $this->api_secret;
     }
@@ -123,11 +95,9 @@ class TwoFactorAuthConfig extends AbstractEntity
     /**
      * Set api_secret.
      *
-     * @param string $apiSecret
-     *
-     * @return TwoFactorAuthConfig
+     * @return $this
      */
-    public function setApiSecret($apiSecret)
+    public function setApiSecret(?string $apiSecret): self
     {
         $this->api_secret = $apiSecret;
 
@@ -136,10 +106,8 @@ class TwoFactorAuthConfig extends AbstractEntity
 
     /**
      * Get from phone number.
-     *
-     * @return string
      */
-    public function getFromPhoneNumber()
+    public function getFromPhoneNumber(): ?string
     {
         return $this->from_phone_number;
     }
@@ -147,18 +115,19 @@ class TwoFactorAuthConfig extends AbstractEntity
     /**
      * Set from phone number.
      *
-     * @param string $fromPhoneNumber
-     *
-     * @return TwoFactorAuthConfig
+     * @return $this
      */
-    public function setFromPhoneNumber(string $fromPhoneNumber)
+    public function setFromPhoneNumber(string $fromPhoneNumber): self
     {
         $this->from_phone_number = $fromPhoneNumber;
 
         return $this;
     }
 
-    public function addIncludeRoute(string $route)
+    /**
+     * @return $this
+     */
+    public function addIncludeRoute(string $route): self
     {
         $routes = $this->getRoutes($this->getIncludeRoutes());
 
@@ -180,10 +149,8 @@ class TwoFactorAuthConfig extends AbstractEntity
 
     /**
      * Get include_routes.
-     *
-     * @return string|null
      */
-    public function getIncludeRoutes()
+    public function getIncludeRoutes(): ?string
     {
         return $this->include_routes;
     }
@@ -191,18 +158,19 @@ class TwoFactorAuthConfig extends AbstractEntity
     /**
      * Set include_routes.
      *
-     * @param string|null $include_routes
-     *
-     * @return TwoFactorAuthConfig
+     * @return $this
      */
-    public function setIncludeRoutes($include_routes = null)
+    public function setIncludeRoutes(?string $include_routes = null): self
     {
         $this->include_routes = $include_routes;
 
         return $this;
     }
 
-    public function removeIncludeRoute(string $route)
+    /**
+     * @return $this
+     */
+    public function removeIncludeRoute(string $route): self
     {
         $routes = $this->getRoutes($this->getIncludeRoutes());
 
@@ -220,20 +188,15 @@ class TwoFactorAuthConfig extends AbstractEntity
     }
 
     /**
-     * @param string|null $plain_api_secret
-     *
-     * @return TwoFactorAuthConfig
+     * @return $this
      */
-    public function setPlainApiSecret(?string $plain_api_secret): TwoFactorAuthConfig
+    public function setPlainApiSecret(?string $plain_api_secret): self
     {
         $this->plain_api_secret = $plain_api_secret;
 
         return $this;
     }
 
-    /**
-     * @return mixed
-     */
     public function getPlainApiSecret(): ?string
     {
         return $this->plain_api_secret;

--- a/Entity/TwoFactorAuthCustomerCookie.php
+++ b/Entity/TwoFactorAuthCustomerCookie.php
@@ -115,7 +115,7 @@ class TwoFactorAuthCustomerCookie extends AbstractEntity
         return $this->cookie_expire_date;
     }
 
-    public function setCookieExpireDate(\DateTime $cookie_expire_date): void
+    public function setCookieExpireDate(?\DateTime $cookie_expire_date): void
     {
         $this->cookie_expire_date = $cookie_expire_date;
     }

--- a/Entity/TwoFactorAuthCustomerCookie.php
+++ b/Entity/TwoFactorAuthCustomerCookie.php
@@ -11,185 +11,120 @@
  * file that was distributed with this source code.
  */
 
-namespace Plugin\TwoFactorAuthCustomer42\Entity;
+namespace Plugin\TwoFactorAuthCustomer44\Entity;
 
-use DateTime;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Eccube\Entity\AbstractEntity;
 use Eccube\Entity\Customer;
+use Plugin\TwoFactorAuthCustomer44\Repository\TwoFactorAuthCustomerCookieRepository;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 /**
  * TwoFactorCustomerCookie
- *
- * @ORM\Table(name="plg_two_factor_customer_cookie")
- * @ORM\InheritanceType("SINGLE_TABLE")
- * @ORM\DiscriminatorColumn(name="discriminator_type", type="string", length=255)
- * @ORM\HasLifecycleCallbacks()
- * @ORM\Entity(repositoryClass="Plugin\TwoFactorAuthCustomer42\Repository\TwoFactorAuthConfigRepository")
- * @UniqueEntity("id")
  */
+#[ORM\Table(name: 'plg_two_factor_customer_cookie')]
+#[ORM\InheritanceType('SINGLE_TABLE')]
+#[ORM\DiscriminatorColumn(name: 'discriminator_type', type: Types::STRING, length: 255)]
+#[ORM\HasLifecycleCallbacks]
+#[ORM\Entity(repositoryClass: TwoFactorAuthCustomerCookieRepository::class)]
+#[UniqueEntity('id')]
 class TwoFactorAuthCustomerCookie extends AbstractEntity
 {
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="id", type="integer", options={"unsigned":true})
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="IDENTITY")
-     */
-    private int $id;
-    /**
-     * @var Customer
-     *
-     * @ORM\ManyToOne(targetEntity="Eccube\Entity\Customer", inversedBy="TwoFactorCustomerCookie")
-     * @ORM\JoinColumns({
-     *   @ORM\JoinColumn(name="customer_id", referencedColumnName="id")
-     * })
-     */
-    private Customer $Customer;
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="cookie_name", type="string", nullable=false, length=512)
-     */
-    private string $cookie_name;
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="cookie_value", type="string", nullable=false, length=512, unique=true)
-     */
-    private string $cookie_value;
-    /**
-     * @var \DateTime
-     *
-     * @ORM\Column(name="cookie_expire_date", type="datetime", nullable=true)
-     */
-    private ?\DateTime $cookie_expire_date;
-    /**
-     * @var \DateTime
-     *
-     * @ORM\Column(name="created_at", type="datetime", nullable=false)
-     */
-    private \DateTime $createdAt;
-    /**
-     * @var \DateTime
-     *
-     * @ORM\Column(name="updated_at", type="datetime", nullable=false)
-     */
-    private \DateTime $updatedAt;
+    #[ORM\Column(name: 'id', type: Types::INTEGER, options: ['unsigned' => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    private ?int $id = null;
 
-    /**
-     * @ORM\PrePersist
-     * @ORM\PreUpdate
-     */
+    #[ORM\ManyToOne(targetEntity: Customer::class, inversedBy: 'TwoFactorAuthCustomerCookies')]
+    #[ORM\JoinColumn(name: 'customer_id', referencedColumnName: 'id')]
+    private ?Customer $Customer = null;
+
+    #[ORM\Column(name: 'cookie_name', type: Types::STRING, nullable: false, length: 512)]
+    private string $cookie_name;
+
+    #[ORM\Column(name: 'cookie_value', type: Types::STRING, nullable: false, length: 512, unique: true)]
+    private string $cookie_value;
+
+    #[ORM\Column(name: 'cookie_expire_date', type: Types::DATETIME_MUTABLE, nullable: true)]
+    private ?\DateTime $cookie_expire_date = null;
+
+    #[ORM\Column(name: 'created_at', type: Types::DATETIME_MUTABLE, nullable: false)]
+    private ?\DateTime $createdAt = null;
+
+    #[ORM\Column(name: 'updated_at', type: Types::DATETIME_MUTABLE, nullable: false)]
+    private ?\DateTime $updatedAt = null;
+
+    #[ORM\PrePersist]
+    #[ORM\PreUpdate]
     public function updatedTimestamps(): void
     {
         $this->setUpdatedAt(new \DateTime('now'));
-        if (!isset($this->createdAt) || $this->getCreatedAt() === null) {
+        if ($this->getCreatedAt() === null) {
             $this->setCreatedAt(new \DateTime('now'));
         }
     }
 
-    /**
-     * @return \DateTime
-     */
-    public function getCreatedAt(): \DateTime
+    public function getCreatedAt(): ?\DateTime
     {
         return $this->createdAt;
     }
 
-    /**
-     * @param \DateTime $createdAt
-     */
     public function setCreatedAt(\DateTime $createdAt): void
     {
         $this->createdAt = $createdAt;
     }
 
-    /**
-     * @return int
-     */
-    public function getId(): int
+    public function getId(): ?int
     {
         return $this->id;
     }
 
-    /**
-     * @return Customer
-     */
-    public function getCustomer(): Customer
+    public function getCustomer(): ?Customer
     {
         return $this->Customer;
     }
 
-    /**
-     * @param Customer $Customer
-     */
     public function setCustomer(Customer $Customer): void
     {
         $this->Customer = $Customer;
     }
 
-    /**
-     * @return string
-     */
     public function getCookieName(): string
     {
         return $this->cookie_name;
     }
 
-    /**
-     * @param string $cookie_name
-     */
     public function setCookieName(string $cookie_name): void
     {
         $this->cookie_name = $cookie_name;
     }
 
-    /**
-     * @return string
-     */
     public function getCookieValue(): string
     {
         return $this->cookie_value;
     }
 
-    /**
-     * @param string $cookie_value
-     */
     public function setCookieValue(string $cookie_value): void
     {
         $this->cookie_value = $cookie_value;
     }
 
-    /**
-     * @return \DateTime
-     */
-    public function getCookieExpireDate(): \DateTime
+    public function getCookieExpireDate(): ?\DateTime
     {
         return $this->cookie_expire_date;
     }
 
-    /**
-     * @param \DateTime $cookie_expire_date
-     */
     public function setCookieExpireDate(\DateTime $cookie_expire_date): void
     {
         $this->cookie_expire_date = $cookie_expire_date;
     }
 
-    /**
-     * @return \DateTime
-     */
-    public function getUpdatedAt(): \DateTime
+    public function getUpdatedAt(): ?\DateTime
     {
         return $this->updatedAt;
     }
 
-    /**
-     * @param \DateTime $updatedAt
-     */
     public function setUpdatedAt(\DateTime $updatedAt): void
     {
         $this->updatedAt = $updatedAt;

--- a/Entity/TwoFactorAuthType.php
+++ b/Entity/TwoFactorAuthType.php
@@ -11,53 +11,38 @@
  * file that was distributed with this source code.
  */
 
-namespace Plugin\TwoFactorAuthCustomer42\Entity;
+namespace Plugin\TwoFactorAuthCustomer44\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Eccube\Entity\AbstractEntity;
+use Plugin\TwoFactorAuthCustomer44\Repository\TwoFactorAuthTypeRepository;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 /**
- * TwoFactorConfig
- *
- * @ORM\Table(name="plg_two_factor_auth_type")
- * @ORM\InheritanceType("SINGLE_TABLE")
- * @ORM\DiscriminatorColumn(name="discriminator_type", type="string", length=255)
- * @ORM\HasLifecycleCallbacks()
- * @ORM\Entity(repositoryClass="Plugin\TwoFactorAuthCustomer42\Repository\TwoFactorAuthTypeRepository")
- * @UniqueEntity("id")
+ * TwoFactorAuthType
  */
+#[ORM\Table(name: 'plg_two_factor_auth_type')]
+#[ORM\InheritanceType('SINGLE_TABLE')]
+#[ORM\DiscriminatorColumn(name: 'discriminator_type', type: Types::STRING, length: 255)]
+#[ORM\HasLifecycleCallbacks]
+#[ORM\Entity(repositoryClass: TwoFactorAuthTypeRepository::class)]
+#[UniqueEntity('id')]
 class TwoFactorAuthType extends AbstractEntity
 {
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="id", type="integer", options={"unsigned":true})
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="IDENTITY")
-     */
-    private $id;
+    #[ORM\Column(name: 'id', type: Types::INTEGER, options: ['unsigned' => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    private ?int $id = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="name", type="string", nullable=false, length=200, unique=true)
-     */
-    private $name;
+    #[ORM\Column(name: 'name', type: Types::STRING, nullable: false, length: 200, unique: true)]
+    private ?string $name = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="route", type="string", nullable=false, length=200, unique=true)
-     */
-    private $route = null;
+    #[ORM\Column(name: 'route', type: Types::STRING, nullable: false, length: 200, unique: true)]
+    private ?string $route = null;
 
-    /**
-     * @var boolean
-     *
-     * @ORM\Column(name="is_disabled", type="boolean", nullable=false)
-     */
-    private $isDisabled = false;
+    #[ORM\Column(name: 'is_disabled', type: Types::BOOLEAN, nullable: false)]
+    private bool $isDisabled = false;
 
     /**
      * Constructor.
@@ -68,20 +53,16 @@ class TwoFactorAuthType extends AbstractEntity
 
     /**
      * Get id.
-     *
-     * @return int
      */
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }
 
     /**
      * Get name.
-     *
-     * @return string
      */
-    public function getName()
+    public function getName(): ?string
     {
         return $this->name;
     }
@@ -89,11 +70,9 @@ class TwoFactorAuthType extends AbstractEntity
     /**
      * Set name.
      *
-     * @param string $name
-     *
-     * @return TwoFactorAuthType
+     * @return $this
      */
-    public function setName($name)
+    public function setName(string $name): self
     {
         $this->name = $name;
 
@@ -102,10 +81,8 @@ class TwoFactorAuthType extends AbstractEntity
 
     /**
      * Get route.
-     *
-     * @return string
      */
-    public function getRoute()
+    public function getRoute(): ?string
     {
         return $this->route;
     }
@@ -113,28 +90,20 @@ class TwoFactorAuthType extends AbstractEntity
     /**
      * Set route.
      *
-     * @param string $route
-     *
-     * @return TwoFactorAuthType
+     * @return $this
      */
-    public function setRoute($route)
+    public function setRoute(string $route): self
     {
         $this->route = $route;
 
         return $this;
     }
 
-    /**
-     * @return bool
-     */
     public function isDisabled(): bool
     {
         return $this->isDisabled;
     }
 
-    /**
-     * @param bool $isDisabled
-     */
     public function setIsDisabled(bool $isDisabled): void
     {
         $this->isDisabled = $isDisabled;

--- a/Event.php
+++ b/Event.php
@@ -11,10 +11,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Plugin\TwoFactorAuthCustomer42;
+namespace Plugin\TwoFactorAuthCustomer44;
 
 use Eccube\Event\TemplateEvent;
-use Plugin\TwoFactorAuthCustomer42\Repository\TwoFactorAuthTypeRepository;
+use Plugin\TwoFactorAuthCustomer44\Repository\TwoFactorAuthTypeRepository;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -51,15 +51,15 @@ class Event implements EventSubscriberInterface
      *
      * @param TemplateEvent $event
      */
-    public function onRenderAdminShopSettingEdit(TemplateEvent $event)
+    public function onRenderAdminShopSettingEdit(TemplateEvent $event): void
     {
         // add 本人確認認証 twig
-        $twig = 'TwoFactorAuthCustomer42/Resource/template/admin/shop_edit_sms.twig';
+        $twig = '@TwoFactorAuthCustomer44/admin/shop_edit_sms.twig';
         $event->addSnippet($twig);
 
         if ($this->hasActiveAuthType) {
             // add ２段階認証設定 twig
-            $twig = 'TwoFactorAuthCustomer42/Resource/template/admin/shop_edit_tfa.twig';
+            $twig = '@TwoFactorAuthCustomer44/admin/shop_edit_tfa.twig';
             $event->addSnippet($twig);
         }
     }
@@ -70,10 +70,10 @@ class Event implements EventSubscriberInterface
      *
      * @param TemplateEvent $event
      */
-    public function onRenderAdminCustomerEdit(TemplateEvent $event)
+    public function onRenderAdminCustomerEdit(TemplateEvent $event): void
     {
         // add twig
-        $twig = 'TwoFactorAuthCustomer42/Resource/template/admin/customer_edit.twig';
+        $twig = '@TwoFactorAuthCustomer44/admin/customer_edit.twig';
         $event->addSnippet($twig);
     }
 }

--- a/EventListener/CustomerPersonalValidationListener.php
+++ b/EventListener/CustomerPersonalValidationListener.php
@@ -11,14 +11,14 @@
  * file that was distributed with this source code.
  */
 
-namespace Plugin\TwoFactorAuthCustomer42\EventListener;
+namespace Plugin\TwoFactorAuthCustomer44\EventListener;
 
 use Eccube\Entity\BaseInfo;
 use Eccube\Repository\BaseInfoRepository;
 use Eccube\Repository\CustomerRepository;
 use Eccube\Request\Context;
-use Plugin\TwoFactorAuthCustomer42\Repository\TwoFactorAuthTypeRepository;
-use Plugin\TwoFactorAuthCustomer42\Service\CustomerTwoFactorAuthService;
+use Plugin\TwoFactorAuthCustomer44\Repository\TwoFactorAuthTypeRepository;
+use Plugin\TwoFactorAuthCustomer44\Service\CustomerTwoFactorAuthService;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Session\Session;

--- a/EventListener/CustomerTwoFactorAuthListener.php
+++ b/EventListener/CustomerTwoFactorAuthListener.php
@@ -11,7 +11,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Plugin\TwoFactorAuthCustomer42\EventListener;
+namespace Plugin\TwoFactorAuthCustomer44\EventListener;
 
 use Eccube\Common\EccubeConfig;
 use Eccube\Entity\BaseInfo;
@@ -19,9 +19,9 @@ use Eccube\Entity\Customer;
 use Eccube\Entity\Master\CustomerStatus;
 use Eccube\Repository\BaseInfoRepository;
 use Eccube\Request\Context;
-use Plugin\TwoFactorAuthCustomer42\Repository\TwoFactorAuthTypeRepository;
-use Plugin\TwoFactorAuthCustomer42\Repository\TwoFactorAuthCustomerCookieRepository;
-use Plugin\TwoFactorAuthCustomer42\Service\CustomerTwoFactorAuthService;
+use Plugin\TwoFactorAuthCustomer44\Repository\TwoFactorAuthTypeRepository;
+use Plugin\TwoFactorAuthCustomer44\Repository\TwoFactorAuthCustomerCookieRepository;
+use Plugin\TwoFactorAuthCustomer44\Service\CustomerTwoFactorAuthService;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -163,10 +163,8 @@ class CustomerTwoFactorAuthListener implements EventSubscriberInterface
      * ログイン完了 イベントハンドラ.
      *
      * @param LoginSuccessEvent $event
-     *
-     * @return RedirectResponse|void
      */
-    public function onLoginSuccess(LoginSuccessEvent $event)
+    public function onLoginSuccess(LoginSuccessEvent $event): void
     {
         if ($this->requestContext->isAdmin()) {
             // バックエンドURLの場合処理なし
@@ -186,7 +184,9 @@ class CustomerTwoFactorAuthListener implements EventSubscriberInterface
         if ($this->requestContext->getCurrentUser()->getTwoFactorAuthType() !== null &&
             $this->requestContext->getCurrentUser()->getTwoFactorAuthType()->isDisabled()) {
             // ユーザーが選択した２段階認証方式は無効になっている場合、ログアウトさせる。
-            return new RedirectResponse($this->router->generate('logout'), 302);
+            $event->setResponse(new RedirectResponse($this->router->generate('logout'), 302));
+
+            return;
         }
 
         $this->multiFactorAuth(

--- a/Form/Type/Extension/Admin/TwoFactorAuthBaseSettingTypeExtension.php
+++ b/Form/Type/Extension/Admin/TwoFactorAuthBaseSettingTypeExtension.php
@@ -11,12 +11,12 @@
  * file that was distributed with this source code.
  */
 
-namespace Plugin\TwoFactorAuthCustomer42\Form\Type\Extension\Admin;
+namespace Plugin\TwoFactorAuthCustomer44\Form\Type\Extension\Admin;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Eccube\Form\Type\Admin\ShopMasterType;
 use Eccube\Form\Type\ToggleSwitchType;
-use Plugin\TwoFactorAuthCustomer42\Entity\TwoFactorAuthType;
+use Plugin\TwoFactorAuthCustomer44\Entity\TwoFactorAuthType;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
@@ -54,7 +54,7 @@ class TwoFactorAuthBaseSettingTypeExtension extends AbstractTypeExtension
      * @param FormBuilderInterface $builder
      * @param array $options
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         if (!empty($options['skip_add_form'])) {
             return;

--- a/Form/Type/Extension/Admin/TwoFactorAuthCustomerTypeExtension.php
+++ b/Form/Type/Extension/Admin/TwoFactorAuthCustomerTypeExtension.php
@@ -11,13 +11,13 @@
  * file that was distributed with this source code.
  */
 
-namespace Plugin\TwoFactorAuthCustomer42\Form\Type\Extension\Admin;
+namespace Plugin\TwoFactorAuthCustomer44\Form\Type\Extension\Admin;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Eccube\Form\Type\Admin\CustomerType;
 use Eccube\Form\Type\PhoneNumberType;
 use Eccube\Form\Type\ToggleSwitchType;
-use Plugin\TwoFactorAuthCustomer42\Entity\TwoFactorAuthType;
+use Plugin\TwoFactorAuthCustomer44\Entity\TwoFactorAuthType;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -56,7 +56,7 @@ class TwoFactorAuthCustomerTypeExtension extends AbstractTypeExtension
      * @param FormBuilderInterface $builder
      * @param array $options
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         if (!empty($options['skip_add_form'])) {
             return;

--- a/Form/Type/TwoFactorAuthAppTypeCustomer.php
+++ b/Form/Type/TwoFactorAuthAppTypeCustomer.php
@@ -11,7 +11,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Plugin\TwoFactorAuthCustomer42\Form\Type;
+namespace Plugin\TwoFactorAuthCustomer44\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
@@ -24,7 +24,7 @@ class TwoFactorAuthAppTypeCustomer extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add(

--- a/Form/Type/TwoFactorAuthConfigType.php
+++ b/Form/Type/TwoFactorAuthConfigType.php
@@ -11,10 +11,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Plugin\TwoFactorAuthCustomer42\Form\Type;
+namespace Plugin\TwoFactorAuthCustomer44\Form\Type;
 
 use Eccube\Common\EccubeConfig;
-use Plugin\TwoFactorAuthCustomer42\Entity\TwoFactorAuthConfig;
+use Plugin\TwoFactorAuthCustomer44\Entity\TwoFactorAuthConfig;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -46,7 +46,7 @@ class TwoFactorAuthConfigType extends AbstractType
         $this->validator = $validator;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('api_key', TextType::class, [

--- a/Form/Type/TwoFactorAuthPhoneNumberTypeCustomer.php
+++ b/Form/Type/TwoFactorAuthPhoneNumberTypeCustomer.php
@@ -11,7 +11,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Plugin\TwoFactorAuthCustomer42\Form\Type;
+namespace Plugin\TwoFactorAuthCustomer44\Form\Type;
 
 use Eccube\Form\Type\PhoneNumberType;
 use Symfony\Component\Form\AbstractType;
@@ -22,7 +22,7 @@ class TwoFactorAuthPhoneNumberTypeCustomer extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('phone_number', PhoneNumberType::class, [

--- a/Form/Type/TwoFactorAuthSmsTypeCustomer.php
+++ b/Form/Type/TwoFactorAuthSmsTypeCustomer.php
@@ -11,7 +11,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Plugin\TwoFactorAuthCustomer42\Form\Type;
+namespace Plugin\TwoFactorAuthCustomer44\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -23,7 +23,7 @@ class TwoFactorAuthSmsTypeCustomer extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add(

--- a/Form/Type/TwoFactorAuthTypeCustomer.php
+++ b/Form/Type/TwoFactorAuthTypeCustomer.php
@@ -11,10 +11,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Plugin\TwoFactorAuthCustomer42\Form\Type;
+namespace Plugin\TwoFactorAuthCustomer44\Form\Type;
 
 use Doctrine\ORM\EntityRepository;
-use Plugin\TwoFactorAuthCustomer42\Entity\TwoFactorAuthType;
+use Plugin\TwoFactorAuthCustomer44\Entity\TwoFactorAuthType;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -24,7 +24,7 @@ class TwoFactorAuthTypeCustomer extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('two_factor_auth_type', EntityType::class, [

--- a/PluginManager.php
+++ b/PluginManager.php
@@ -11,15 +11,15 @@
  * file that was distributed with this source code.
  */
 
-namespace Plugin\TwoFactorAuthCustomer42;
+namespace Plugin\TwoFactorAuthCustomer44;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Eccube\Common\EccubeConfig;
 use Eccube\Entity\Layout;
 use Eccube\Entity\Page;
 use Eccube\Entity\PageLayout;
 use Eccube\Plugin\AbstractPluginManager;
-use Eccube\Common\EccubeConfig;
-use Plugin\TwoFactorAuthCustomer42\Entity\TwoFactorAuthConfig;
+use Plugin\TwoFactorAuthCustomer44\Entity\TwoFactorAuthConfig;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -29,17 +29,17 @@ use Symfony\Component\Filesystem\Filesystem;
 class PluginManager extends AbstractPluginManager
 {
     // 設定対象ページ情報
-    private $pages = [
-        ['plg_customer_2fa_device_auth_send_onetime', 'デバイス認証送信先入力', 'TwoFactorAuthCustomer42/Resource/template/default/device_auth/send'],
-        ['plg_customer_2fa_device_auth_input_onetime', 'デバイス認証トークン入力', 'TwoFactorAuthCustomer42/Resource/template/default/device_auth/input'],
-        ['plg_customer_2fa_auth_type_select', '多要素認証方式選択', 'TwoFactorAuthCustomer42/Resource/template/default/tfa/select_type'],
+    private array $pages = [
+        ['plg_customer_2fa_device_auth_send_onetime', 'デバイス認証送信先入力', 'TwoFactorAuthCustomer44/Resource/template/default/device_auth/send'],
+        ['plg_customer_2fa_device_auth_input_onetime', 'デバイス認証トークン入力', 'TwoFactorAuthCustomer44/Resource/template/default/device_auth/input'],
+        ['plg_customer_2fa_auth_type_select', '多要素認証方式選択', 'TwoFactorAuthCustomer44/Resource/template/default/tfa/select_type'],
     ];
 
     /**
-     * @param array $meta
+     * @param array<string, mixed> $meta
      * @param ContainerInterface $container
      */
-    public function enable(array $meta, ContainerInterface $container)
+    public function enable(array $meta, ContainerInterface $container): void
     {
         $em = $container->get('doctrine')->getManager();
 
@@ -57,7 +57,7 @@ class PluginManager extends AbstractPluginManager
      *
      * @param EntityManagerInterface $em
      */
-    protected function createConfig(EntityManagerInterface $em)
+    protected function createConfig(EntityManagerInterface $em): void
     {
         $TwoFactorAuthConfig = $em->find(TwoFactorAuthConfig::class, 1);
         if ($TwoFactorAuthConfig) {
@@ -75,17 +75,17 @@ class PluginManager extends AbstractPluginManager
      *
      * @param ContainerInterface $container
      */
-    protected function copyTwigFiles(ContainerInterface $container)
+    protected function copyTwigFiles(ContainerInterface $container): void
     {
         // テンプレートファイルコピー
         $templatePath = $container->get(EccubeConfig::class)->get('eccube_theme_front_dir')
-            . '/TwoFactorAuthCustomer42/Resource/template/default';
+            .'/TwoFactorAuthCustomer44/Resource/template/default';
         $fs = new Filesystem();
         if ($fs->exists($templatePath)) {
             return;
         }
         $fs->mkdir($templatePath);
-        $fs->mirror(__DIR__ . '/Resource/template/default', $templatePath);
+        $fs->mirror(__DIR__.'/Resource/template/default', $templatePath);
     }
 
     /**
@@ -93,7 +93,7 @@ class PluginManager extends AbstractPluginManager
      *
      * @param EntityManagerInterface $em
      */
-    protected function createPages(EntityManagerInterface $em)
+    protected function createPages(EntityManagerInterface $em): void
     {
         foreach ($this->pages as $p) {
             $hasPage = $em->getRepository(Page::class)->count(['url' => $p[0]]) > 0;
@@ -123,10 +123,10 @@ class PluginManager extends AbstractPluginManager
     }
 
     /**
-     * @param array $meta
+     * @param array<string, mixed> $meta
      * @param ContainerInterface $container
      */
-    public function disable(array $meta, ContainerInterface $container)
+    public function disable(array $meta, ContainerInterface $container): void
     {
         $em = $container->get('doctrine')->getManager();
 
@@ -142,10 +142,10 @@ class PluginManager extends AbstractPluginManager
      *
      * @param ContainerInterface $container
      */
-    protected function removeTwigFiles(ContainerInterface $container)
+    protected function removeTwigFiles(ContainerInterface $container): void
     {
         $templatePath = $container->get(EccubeConfig::class)->get('eccube_theme_front_dir')
-            . '/TwoFactorAuthCustomer42';
+            .'/TwoFactorAuthCustomer44';
         $fs = new Filesystem();
         $fs->remove($templatePath);
     }
@@ -155,7 +155,7 @@ class PluginManager extends AbstractPluginManager
      *
      * @param EntityManagerInterface $em
      */
-    protected function removePages(EntityManagerInterface $em)
+    protected function removePages(EntityManagerInterface $em): void
     {
         foreach ($this->pages as $p) {
             $Page = $em->getRepository(Page::class)->findOneBy(['url' => $p[0]]);
@@ -171,17 +171,16 @@ class PluginManager extends AbstractPluginManager
     }
 
     /**
-     * @param array $meta
+     * @param array<string, mixed> $meta
      * @param ContainerInterface $container
      */
-    public function uninstall(array $meta, ContainerInterface $container)
+    public function uninstall(array $meta, ContainerInterface $container): void
     {
-        $em = $container->get('doctrine')->getManager();
-
         // twigファイルを削除
         $this->removeTwigFiles($container);
 
         // ページ削除
+        $em = $container->get('doctrine')->getManager();
         $this->removePages($em);
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# 2段階認証プラグイン
+# 2段階認証プラグイン (EC-CUBE 4.4)
+
+EC-CUBE 4.2/4.3 向け `TwoFactorAuthCustomer42` を EC-CUBE 4.4 / Symfony 7.4 向け `TwoFactorAuthCustomer44` に移行したプラグインです。

--- a/Repository/TwoFactorAuthConfigRepository.php
+++ b/Repository/TwoFactorAuthConfigRepository.php
@@ -11,12 +11,11 @@
  * file that was distributed with this source code.
  */
 
-namespace Plugin\TwoFactorAuthCustomer42\Repository;
+namespace Plugin\TwoFactorAuthCustomer44\Repository;
 
 use Doctrine\Persistence\ManagerRegistry;
 use Eccube\Repository\AbstractRepository;
-use Plugin\TwoFactorAuthCustomer42\Entity\TwoFactorAuthConfig;
-use Plugin\TwoFactorAuthCustomer42\Entity\TwoFactorAuthCustomerCookie;
+use Plugin\TwoFactorAuthCustomer44\Entity\TwoFactorAuthConfig;
 
 /**
  * TwoFactorAuthConfigRepository.
@@ -37,7 +36,7 @@ class TwoFactorAuthConfigRepository extends AbstractRepository
     }
 
     /**
-     * @return object|TwoFactorAuthConfig|TwoFactorAuthCustomerCookie|null $result
+     * @return TwoFactorAuthConfig|null
      */
     public function findOne()
     {

--- a/Repository/TwoFactorAuthCustomerCookieRepository.php
+++ b/Repository/TwoFactorAuthCustomerCookieRepository.php
@@ -11,14 +11,14 @@
  * file that was distributed with this source code.
  */
 
-namespace Plugin\TwoFactorAuthCustomer42\Repository;
+namespace Plugin\TwoFactorAuthCustomer44\Repository;
 
 use Carbon\Carbon;
 use Doctrine\Persistence\ManagerRegistry;
 use Eccube\Entity\Customer;
 use Eccube\Repository\AbstractRepository;
 use Eccube\Util\StringUtil;
-use Plugin\TwoFactorAuthCustomer42\Entity\TwoFactorAuthCustomerCookie;
+use Plugin\TwoFactorAuthCustomer44\Entity\TwoFactorAuthCustomerCookie;
 
 /**
  * TwoFactorAuthConfigRepository.

--- a/Repository/TwoFactorAuthCustomerCookieRepository.php
+++ b/Repository/TwoFactorAuthCustomerCookieRepository.php
@@ -88,11 +88,9 @@ class TwoFactorAuthCustomerCookieRepository extends AbstractRepository
             ->where('tfcc.Customer = :customer_id')
             ->andWhere('tfcc.cookie_name = :cookie_name')
             ->andWhere('tfcc.cookie_expire_date < :expire_date')
-            ->setParameters([
-                'customer_id' => $customer->getId(),
-                'cookie_name' => $cookieName,
-                'expire_date' => $expireDate,
-            ])
+            ->setParameter('customer_id', $customer->getId())
+            ->setParameter('cookie_name', $cookieName)
+            ->setParameter('expire_date', $expireDate)
             ->getQuery()
             ->getResult();
     }
@@ -120,11 +118,9 @@ class TwoFactorAuthCustomerCookieRepository extends AbstractRepository
             ->where('tfcc.Customer = :customer_id')
             ->andWhere('tfcc.cookie_name = :cookie_name')
             ->andWhere('tfcc.cookie_expire_date > :expire_date')
-            ->setParameters([
-                'customer_id' => $customer->getId(),
-                'cookie_name' => $cookieName,
-                'expire_date' => $expireDate,
-            ])
+            ->setParameter('customer_id', $customer->getId())
+            ->setParameter('cookie_name', $cookieName)
+            ->setParameter('expire_date', $expireDate)
             ->getQuery()
             ->getResult();
     }

--- a/Repository/TwoFactorAuthTypeRepository.php
+++ b/Repository/TwoFactorAuthTypeRepository.php
@@ -11,11 +11,11 @@
  * file that was distributed with this source code.
  */
 
-namespace Plugin\TwoFactorAuthCustomer42\Repository;
+namespace Plugin\TwoFactorAuthCustomer44\Repository;
 
 use Doctrine\Persistence\ManagerRegistry;
 use Eccube\Repository\AbstractRepository;
-use Plugin\TwoFactorAuthCustomer42\Entity\TwoFactorAuthType;
+use Plugin\TwoFactorAuthCustomer44\Entity\TwoFactorAuthType;
 
 /**
  * TwoFactorAuthTypeRepository.

--- a/Resource/.php-cs-fixer.dist.php
+++ b/Resource/.php-cs-fixer.dist.php
@@ -1,0 +1,57 @@
+<?php
+
+if (php_sapi_name() !== 'cli') {
+    throw new \LogicException();
+}
+
+$header = <<<EOL
+This file is part of EC-CUBE
+
+Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+
+https://www.ec-cube.co.jp/
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+EOL;
+
+$rules = [
+    '@Symfony' => true,
+    'array_syntax' => ['syntax' => 'short'],
+    'phpdoc_align' => false,
+    'phpdoc_summary' => false,
+    'phpdoc_annotation_without_dot' => false,
+    'no_superfluous_phpdoc_tags' => false,
+    'increment_style' => false,
+    'yoda_style' => false,
+    'header_comment' => ['header' => $header],
+    'phpdoc_add_missing_param_annotation' => true,
+    'phpdoc_param_order' => true,
+    'phpdoc_to_comment' => false, // /** @var */ を変換してしまうため
+    'phpdoc_trim' => true,
+    'global_namespace_import' => [
+        'import_classes' => false,
+        'import_constants' => false,
+        'import_functions' => false,
+    ],
+    // PHPDocの型をネイティブ型へ
+    'phpdoc_to_param_type' => true,
+    'phpdoc_to_return_type' => true,
+    // プロパティのネイティブ型化は無効。EC-CUBE のテスト基盤が tearDown で全プロパティに
+    // null を代入するため、テストプロパティを非null native 型にすると TypeError になる。
+    'phpdoc_to_property_type' => false,
+];
+
+$finder = \PhpCsFixer\Finder::create()
+    ->in(dirname(__DIR__))
+    ->exclude(['vendor', 'node_modules', 'Resource'])
+    ->name('*.php')
+;
+$config = new \PhpCsFixer\Config();
+
+return $config
+    ->setRules($rules)
+    ->setFinder($finder)
+    ->setRiskyAllowed(true)
+    ->setUnsupportedPhpVersionAllowed(true)
+;

--- a/Resource/rector.php
+++ b/Resource/rector.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Rector\Config\RectorConfig;
+use Rector\Doctrine\Set\DoctrineSetList;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+use Rector\Set\ValueObject\LevelSetList;
+use Rector\Symfony\Set\SymfonySetList;
+use Rector\ValueObject\PhpVersion;
+
+return RectorConfig::configure()
+    // EC-CUBE 4.4 の最小サポートバージョンに合わせる
+    ->withPhpVersion(PhpVersion::PHP_82)
+    // プラグインのソースディレクトリ
+    ->withPaths([
+        dirname(__DIR__).'/Controller',
+        dirname(__DIR__).'/Entity',
+        dirname(__DIR__).'/Form',
+        dirname(__DIR__).'/Repository',
+        dirname(__DIR__).'/Service',
+        dirname(__DIR__).'/EventListener',
+        dirname(__DIR__).'/PluginManager.php',
+        dirname(__DIR__).'/Event.php',
+    ])
+    ->withSkip([
+        dirname(__DIR__).'/vendor',
+        dirname(__DIR__).'/node_modules',
+    ])
+    ->withSets([
+        LevelSetList::UP_TO_PHP_82,
+        // Symfony 7.4 対応 (@Route → #[Route], @Template, buildForm(): void 等)
+        SymfonySetList::SYMFONY_74,
+        SymfonySetList::SYMFONY_CODE_QUALITY,
+        // Doctrine ORM 3.0 / DBAL 3.0 対応 (@ORM → #[ORM], 型付きプロパティ)
+        DoctrineSetList::DOCTRINE_CODE_QUALITY,
+        DoctrineSetList::DOCTRINE_DBAL_30,
+        DoctrineSetList::ANNOTATIONS_TO_ATTRIBUTES,
+    ])
+    // Symfony/Doctrine 等のアノテーション → アトリビュート変換を有効化
+    ->withAttributesSets()
+    // #[Route] は付与されるが use 文が旧 Annotation のまま残るため Attribute へ統一する
+    ->withConfiguredRule(RenameClassRector::class, [
+        'Symfony\Component\Routing\Annotation\Route' => 'Symfony\Component\Routing\Attribute\Route',
+    ])
+    ->withImportNames(
+        importShortClasses: false,
+        importDocBlockNames: true,
+        importNames: true
+    )
+    ->withParallel();

--- a/Resource/template/admin/config.twig
+++ b/Resource/template/admin/config.twig
@@ -9,7 +9,7 @@
 
 {% block main %}
 
-    <form method="post" action="{{ url('two_factor_auth_customer42_admin_config') }}">
+    <form method="post" action="{{ url('two_factor_auth_customer44_admin_config') }}">
         {{ form_widget(form._token) }}
         <div class="c-contentsArea__cols">
             <div class="c-contentsArea__primaryCol">

--- a/Service/CustomerTwoFactorAuthService.php
+++ b/Service/CustomerTwoFactorAuthService.php
@@ -11,23 +11,23 @@
  * file that was distributed with this source code.
  */
 
-namespace Plugin\TwoFactorAuthCustomer42\Service;
+namespace Plugin\TwoFactorAuthCustomer44\Service;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Eccube\Common\EccubeConfig;
 use Eccube\Entity\BaseInfo;
 use Eccube\Entity\Customer;
 use Eccube\Repository\BaseInfoRepository;
-use Plugin\TwoFactorAuthCustomer42\Entity\TwoFactorAuthCustomerCookie;
-use Plugin\TwoFactorAuthCustomer42\Repository\TwoFactorAuthConfigRepository;
-use Plugin\TwoFactorAuthCustomer42\Repository\TwoFactorAuthCustomerCookieRepository;
+use Plugin\TwoFactorAuthCustomer44\Entity\TwoFactorAuthConfig;
+use Plugin\TwoFactorAuthCustomer44\Entity\TwoFactorAuthCustomerCookie;
+use Plugin\TwoFactorAuthCustomer44\Repository\TwoFactorAuthConfigRepository;
+use Plugin\TwoFactorAuthCustomer44\Repository\TwoFactorAuthCustomerCookieRepository;
 use Symfony\Component\DependencyInjection\ParameterBag\ContainerBagInterface;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
-use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 use Twilio\Exceptions\ConfigurationException;
 use Twilio\Exceptions\TwilioException;
 use Twilio\Rest\Client;
@@ -52,10 +52,6 @@ class CustomerTwoFactorAuthService
      * @var EccubeConfig
      */
     protected $eccubeConfig;
-    /**
-     * @var EncoderFactoryInterface
-     */
-    protected $encoderFactory;
     /**
      * @var RequestStack
      */

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * https://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+$loader = require __DIR__.'/../../../../vendor/autoload.php';
+
+$envFile = __DIR__.'/../../../../.env';
+if (file_exists($envFile)) {
+    (new Symfony\Component\Dotenv\Dotenv())->load($envFile);
+}

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,10 @@
 {
-    "name": "ec-cube/twofactorauthcustomer42",
-    "version": "4.3.0",
-    "description": "2 factor authentication for Customers EC-CUBE42",
+    "name": "ec-cube/twofactorauthcustomer44",
+    "version": "4.4.0",
+    "description": "2 factor authentication for Customers EC-CUBE 4.4",
     "type": "eccube-plugin",
     "extra": {
-        "code": "TwoFactorAuthCustomer42"
+        "code": "TwoFactorAuthCustomer44"
     },
     "require": {
         "ec-cube/plugin-installer": "^2.0",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,10 @@
+parameters:
+    level: 6
+    paths:
+        - .
+    excludePaths:
+        - Resource/*
+        - Tests/bootstrap.php
+    doctrine:
+        objectManagerLoader: ../../../tests/object-manager.php
+        ormRepositoryClass: Eccube\Repository\AbstractRepository

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<!-- https://phpunit.readthedocs.io/en/latest/configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="Tests/bootstrap.php"
 >
     <php>
-        <ini name="error_reporting" value="-1"/>
-        <env name="KERNEL_CLASS" value="Eccube\Kernel"/>
-        <env name="APP_ENV" value="test"/>
-        <env name="APP_DEBUG" value="1"/>
-        <env name="SHELL_VERBOSITY" value="-1"/>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
-        <env name="SYMFONY_PHPUNIT_VERSION" value="9.5"/>
-        <!-- define your env variables for the test env here -->
+        <ini name="memory_limit" value="-1" />
+        <ini name="display_errors" value="1" />
+        <ini name="error_reporting" value="-1" />
+        <server name="KERNEL_CLASS" value="Eccube\Kernel" />
+        <server name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
+        <server name="APP_ENV" value="test" force="true" />
+        <server name="SHELL_VERBOSITY" value="-1" />
     </php>
 
     <!-- テストの場所 -->
@@ -24,26 +24,20 @@
         </testsuite>
     </testsuites>
 
-    <!-- 出力するログファイル
-    <logging>
-        <log type="coverage-clover" target="./reports/coverage.clover"/>
-    </logging>
-    -->
-
-    <!-- カバーレージのターゲット -->
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <!-- カバレッジのターゲット -->
+    <source>
+        <include>
             <directory suffix=".php">./</directory>
-            <exclude>
-                <directory suffix=".php">./Tests</directory>
-                <directory suffix=".php">./Resource</directory>
-                <file>./PluginManager.php</file>
-            </exclude>
-        </whitelist>
-    </filter>
+        </include>
+        <exclude>
+            <directory suffix=".php">./Tests</directory>
+            <directory suffix=".php">./Resource</directory>
+            <file>./PluginManager.php</file>
+        </exclude>
+    </source>
 
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-        <listener class="\DAMA\DoctrineTestBundle\PHPUnit\PHPUnitListener"/>
-    </listeners>
+    <!-- DAMA DoctrineTestBundle によりテストごとに DB をトランザクションでロールバックする -->
+    <extensions>
+        <bootstrap class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension"/>
+    </extensions>
 </phpunit>


### PR DESCRIPTION
## 概要

会員向け2段階認証プラグインを **EC-CUBE 4.4（Symfony 7.4 / Doctrine ORM 3.0 / PHP 8.2+）** に対応させ、コードを `TwoFactorAuthCustomer42` → **`TwoFactorAuthCustomer44`** に改名します。4.3 とは非互換（属性必須・ORM 3・PHP 8.2+）のため、新規 `4.4` ブランチへの取り込みです。

参考: [4.3→4.4 マイグレーション手順 (doc #346)](https://github.com/EC-CUBE/doc4.ec-cube.net/pull/346/changes) / 参照 [Recommend-plugin #67](https://github.com/EC-CUBE/Recommend-plugin/pull/67) 

## 変更内容

### 1. EC-CUBE 4.4 対応（コア移行）

- **Annotations → PHP 属性**: Entity の `@ORM\*` → `#[ORM\*]`、Controller の `@Route`/`@Template` → `#[Route]`/`#[Template]`（`Sensio` 依存除去）
- **型宣言の明示**: Entity プロパティの型付け（`?int`/`?string`/`?\DateTime` 等）、ゲッター/セッター・各メソッドの戻り値型
- **constructor property promotion / readonly**: Controller 等の DI を現代化
- **Doctrine ORM 3.0**: `flush($entity)` → `flush()`、QueryBuilder の `setParameters([...])` → `setParameter()` へ変更（型付きパラメータ対応）
- **AbstractPluginManager**: `enable`/`disable` ほか関連メソッドに `: void`
- **テンプレート参照**: パス文字列 / `@TwoFactorAuthCustomer44/...` エイリアスへ統一
- **PHPUnit 11**: `phpunit.xml.dist` を `<source>`/`<extensions>` 形式へ、`Tests/bootstrap.php` を追加
- **コード名**: namespace / composer `code` / `version: 4.4.0` / 管理画面ルートを `TwoFactorAuthCustomer44` に統一
- **フォローアップ修正**: Cookie 有効期限セッターの nullable 対応、Repository クエリパラメータ設定の修正

### 2. 静的解析・整形ツール

- `phpstan.neon.dist`（level 6）/ `Resource/rector.php` / `Resource/.php-cs-fixer.dist.php` を追加（`.php` 設定は本体の `Plugin\:` サービス検出で 500 を避けるため `Resource/` 配下に配置）
- rector / php-cs-fixer を適用し、phpstan level 6 での検査を前提にした構成にする

### 3. CI（`.github/workflows/main.yml` ほか）

- マトリクスを EC-CUBE 4.4 / PHP 8.2–8.5 / MySQL8・PostgreSQL に更新、`checkout@v4`・`$GITHUB_OUTPUT` 化（MySQL 5.7・4.2/4.3 対象は除外）
- プラグイン導入を `eccube:plugin:install --path=...` に変更（mock-package-api 依存を除去）し、PHPUnit 実行ステップを追加
- **`--ignore-platform-req=ext-redis`**: Symfony 7.4 の `symfony/cache` が古い `php-redis` と衝突して本体 composer install が失敗するのを回避（redis は未使用）
- **phpunit 前に `cache:warmup`**: 有効プラグインのルートはコンテナのコンパイル時に確定するため、phpunit プロセスの遅延コンパイルだと `RouteNotFoundException` が断続的に発生する問題を解消
- **static-analysis ジョブ**: php-cs-fixer / rector / phpstan を SQLite・PHP 8.5 の1構成で実行
- `e2e-testing.yml` / `ab-testing.yml`: 関連プラグインコードを `*44`（Customer / App / Sms）に更新
- `release.yml`: 配布パッケージから開発・テスト用ファイル（docker-compose / dockerbuild / CLAUDE.md / phpstan / rector / php-cs-fixer）を除外

## テスト

- EC-CUBE 4.4 環境での手動試験（コミット記載どおり）
- CI マトリクス: 4.4 × PHP 8.2/8.3/8.4/8.5 × MySQL8/PostgreSQL
- 静的解析ジョブ: php-cs-fixer / rector dry-run / phpstan level 6
- 配布パッケージ（`release.yml` 相当）から開発用ファイルが除外されることを確認